### PR TITLE
psr8-25 | version_history function

### DIFF
--- a/semantic_release/enums.py
+++ b/semantic_release/enums.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+from enum import IntEnum
+
+
+class LevelBump(IntEnum):
+    """
+    IntEnum representing valid types of bumps for a version.
+    We use an IntEnum to enable ordering of levels.
+    """
+
+    NO_RELEASE = 0
+    PATCH = 1
+    MINOR = 2
+    MAJOR = 3
+
+    def __str__(self):
+        """
+        Return the level name rather than 'LevelBump.<level>'
+        E.g.
+        >>> str(LevelBump.NO_RELEASE)
+        'no_release'
+        >>> str(LevelBump.MAJOR)
+        'major'
+        """
+        return self.name.lower()
+
+    @classmethod
+    def from_string(cls, val: str) -> LevelBump:
+        """
+        Get the level from string representation. For backwards-compatibility,
+        dashes are replaced with underscores so that:
+        >>> LevelBump.from_string("no-release") == LevelBump.NO_RELEASE
+        Equally,
+        >>> LevelBump.from_string("minor") == LevelBump.MINOR
+        """
+        return cls[val.upper().replace("-", "_")]

--- a/semantic_release/history.py
+++ b/semantic_release/history.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from git import Repo
+
+from semantic_release.version import Version, VersionTranslator
+
+
+def version_history(repo: Repo, translator: VersionTranslator) -> List[Version]:
+    """
+    Given the repository instance and a translator, return a list of Version instances
+    from the Git tags, sorted in descending order according to semantic version
+    specification on precedence.
+    """
+    return sorted((translator.from_tag(tag.name) for tag in repo.tags), reverse=True)
+
+# commit_parser = ...
+# release_scope = max(commit.scope for commit in CommitStream(repo.commits, parser=commit_parser)[version_history[0] :])

--- a/semantic_release/version/__init__.py
+++ b/semantic_release/version/__init__.py
@@ -1,1 +1,2 @@
 from semantic_release.version.translator import VersionTranslator, SEMVER_REGEX
+from semantic_release.version.version import Version

--- a/semantic_release/version/translator.py
+++ b/semantic_release/version/translator.py
@@ -3,7 +3,7 @@ import re
 import string
 from typing import Optional, Union
 
-from semver import VersionInfo as Version
+from semantic_release.version.version import Version
 
 # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 SEMVER_REGEX = re.compile(

--- a/semantic_release/version/version.py
+++ b/semantic_release/version/version.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import semver
+
+from semantic_release.enums import LevelBump
+
+
+class Version(semver.VersionInfo):
+
+    def bump(self, level: LevelBump) -> Version:
+        if level is LevelBump.MAJOR:
+            return self.bump_major()
+        if level is LevelBump.MINOR:
+            return self.bump_minor()
+        if level is LevelBump.PATCH:
+            return self.bump_patch()
+        return self

--- a/tests/unit/semantic_release/test_history.py
+++ b/tests/unit/semantic_release/test_history.py
@@ -1,0 +1,54 @@
+import pytest
+
+from semantic_release.history import version_history
+from semantic_release.version import VersionTranslator, Version
+
+
+@pytest.fixture
+def a_repo_with_certain_tags():
+    # TODO: This is a hacky fixture for sanity testing now,
+    # and should be covered more thoroughly with a fixture with a
+    # full repo of history by testing improvements
+    class Tag:
+        def __init__(self, name):
+            self.name = name
+
+    class Repo:
+        def __init__(self):
+            self.tags = [
+                Tag("v0.1.0"),
+                Tag("v1.0.1"),
+                Tag("v0.2.0"),
+                Tag("v2.1.0"),
+                Tag("v0.3.0-dev.1"),
+                Tag("v1.0.0"),
+                Tag("v0.3.0"),
+                Tag("v2.0.0-alpha.1"),
+                Tag("v2.0.0-rc.1"),
+                Tag("v1.0.4"),
+                Tag("v2.0.0"),
+            ]
+
+    yield Repo()
+
+
+def test_version_history(a_repo_with_certain_tags):
+    translator = VersionTranslator()
+    versions = version_history(a_repo_with_certain_tags, translator)
+
+    assert versions == [
+        Version.parse(v)
+        for v in (
+            "2.1.0",
+            "2.0.0",
+            "2.0.0-rc.1",
+            "2.0.0-alpha.1",
+            "1.0.4",
+            "1.0.1",
+            "1.0.0",
+            "0.3.0",
+            "0.3.0-dev.1",
+            "0.2.0",
+            "0.1.0",
+        )
+    ]


### PR DESCRIPTION
version_history enables sorting of previous versions by tag. Tests need revisiting as part of overhaul of testing with a local repo that has an example history set up