### PR TITLE
psr8-26 | rework commit parsers, add CommitStream class

### DIFF
--- a/semantic_release/commit_parser/__init__.py
+++ b/semantic_release/commit_parser/__init__.py
@@ -1,0 +1,1 @@
+from semantic_release.commit_parser.token import ParsedCommit

--- a/semantic_release/commit_parser/_base.py
+++ b/semantic_release/commit_parser/_base.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Type, Any
+from typing import Type, TypeVar, Generic
 
 from git import Commit
+
+from semantic_release.commit_parser.token import ParseResult
 
 
 class ParserOptions:
@@ -28,7 +30,11 @@ class ParserOptions:
         pass
 
 
-class CommitParser(ABC):
+# TT = TokenType, a subclass of ParsedCommit
+_TT = TypeVar("_TT", bound=ParseResult)
+
+
+class CommitParser(ABC, Generic[_TT]):
     """
     Abstract base class for all commit parsers. Custom commit parsers should inherit
     from this class.
@@ -54,5 +60,5 @@ class CommitParser(ABC):
         self.options = options
 
     @abstractmethod
-    def parse(self, commit: Commit) -> Any:
+    def parse(self, commit: Commit) -> _TT:
         ...

--- a/semantic_release/commit_parser/emoji.py
+++ b/semantic_release/commit_parser/emoji.py
@@ -6,7 +6,8 @@ from typing import Tuple
 from git import Commit
 
 from semantic_release.commit_parser._base import CommitParser, ParserOptions
-from semantic_release.commit_parser.util import ParsedCommit, parse_paragraphs
+from semantic_release.commit_parser.token import ParsedCommit, ParseResult, ParseError
+from semantic_release.commit_parser.util import parse_paragraphs
 
 from semantic_release.enums import LevelBump
 
@@ -44,7 +45,7 @@ class EmojiParserOptions(ParserOptions):
     default_bump_level: LevelBump = LevelBump.NO_RELEASE
 
 
-class EmojiCommitParser(CommitParser):
+class EmojiCommitParser(CommitParser[ParseResult[ParsedCommit, ParseError]]):
     """
     Parse a commit using an emoji in the subject line.
     When multiple emojis are encountered, the one with the highest bump
@@ -59,7 +60,7 @@ class EmojiCommitParser(CommitParser):
 
     parser_options = EmojiParserOptions
 
-    def parse(self, commit: Commit) -> ParsedCommit:
+    def parse(self, commit: Commit) -> ParseResult[ParsedCommit, ParseError]:
         all_emojis = (
             self.options.major_tags + self.options.minor_tags + self.options.patch_tags
         )

--- a/semantic_release/commit_parser/tag.py
+++ b/semantic_release/commit_parser/tag.py
@@ -7,11 +7,8 @@ from git import Commit
 
 from semantic_release.errors import UnknownCommitMessageStyleError
 from semantic_release.commit_parser._base import ParserOptions, CommitParser
-from semantic_release.commit_parser.util import (
-    ParsedCommit,
-    parse_paragraphs,
-    breaking_re,
-)
+from semantic_release.commit_parser.token import ParsedCommit
+from semantic_release.commit_parser.util import parse_paragraphs, breaking_re
 
 from semantic_release.enums import LevelBump
 
@@ -26,7 +23,7 @@ class TagParserOptions(ParserOptions):
     patch_tag: str = ":nut_and_bolt:"
 
 
-class TagCommitParser(CommitParser):
+class TagCommitParser(CommitParser[ParsedCommit]):
     """
     Parse a commit message according to the 1.0 version of python-semantic-release.
     It expects a tag of some sort in the commit message and will use the rest of the first line

--- a/semantic_release/commit_parser/token.py
+++ b/semantic_release/commit_parser/token.py
@@ -1,0 +1,29 @@
+from typing import List, NamedTuple, Union, TypeVar
+
+from git import Commit
+
+from semantic_release.enums import LevelBump
+from semantic_release.errors import CommitParseError
+
+
+class ParsedCommit(NamedTuple):
+    bump: LevelBump
+    type: str
+    scope: str
+    descriptions: List[str]
+    breaking_descriptions: List[str]
+    commit: Commit
+
+
+class ParseError(NamedTuple):
+    commit: Commit
+    error: str
+
+    def raise_error(self):
+        raise CommitParseError(self.error)
+
+
+_T = TypeVar("_T", bound=ParsedCommit)
+_E = TypeVar("_E", bound=ParseError)
+
+ParseResult = Union[_T, _E]

--- a/semantic_release/commit_parser/util.py
+++ b/semantic_release/commit_parser/util.py
@@ -1,9 +1,5 @@
 import re
-from typing import List, NamedTuple
-
-from git import Commit
-
-from semantic_release.enums import LevelBump
+from typing import List
 
 
 breaking_re = re.compile(r"BREAKING[ -]CHANGE:\s?(.*)")
@@ -21,12 +17,3 @@ def parse_paragraphs(text: str) -> List[str]:
         for paragraph in text.split("\n\n")
         if len(paragraph) > 0
     ]
-
-
-class ParsedCommit(NamedTuple):
-    bump: LevelBump
-    type: str
-    scope: str
-    descriptions: List[str]
-    breaking_descriptions: List[str]
-    commit: Commit

--- a/semantic_release/errors.py
+++ b/semantic_release/errors.py
@@ -15,6 +15,10 @@ class UnknownCommitMessageStyleError(SemanticReleaseBaseError):
     pass
 
 
+class CommitParseError(SemanticReleaseBaseError):
+    pass
+
+
 class GitError(SemanticReleaseBaseError):
     pass
 

--- a/tests/unit/semantic_release/test_history.py
+++ b/tests/unit/semantic_release/test_history.py
@@ -52,3 +52,6 @@ def test_version_history(a_repo_with_certain_tags):
             "0.1.0",
         )
     ]
+
+
+def test_next_version_correct(): pass


### PR DESCRIPTION
Reworked commit parsers to use a more traditional ok/err return type, and added an abstraction
over the commit iteration from v7 to encapsulate from/to revisions and error handling logic