### PR TITLE
psr8-24 | add Version.bump method and tests

### DIFF
--- a/semantic_release/version/version.py
+++ b/semantic_release/version/version.py
@@ -6,11 +6,23 @@ from semantic_release.enums import LevelBump
 
 class Version(semver.VersionInfo):
 
-    def bump(self, level: LevelBump) -> Version:
+    def bump(self, level: LevelBump, prerelease: bool = False, prerelease_token: str = "beta") -> Version:
+        # If already a prerelease, bump revision and return
+        if level is LevelBump.NO_RELEASE:
+            # Return a copy rather than the same instance for consistency
+            return Version(*self.to_tuple())
+
+        if self.prerelease and prerelease:
+            return self.bump_prerelease()
+
+        version = self
         if level is LevelBump.MAJOR:
-            return self.bump_major()
-        if level is LevelBump.MINOR:
-            return self.bump_minor()
-        if level is LevelBump.PATCH:
-            return self.bump_patch()
-        return self
+            version = self.bump_major()
+        elif level is LevelBump.MINOR:
+            version = self.bump_minor()
+        elif level is LevelBump.PATCH:
+            version = self.bump_patch()
+
+        if prerelease:
+            version = version.bump_prerelease(token=prerelease_token)
+        return version

--- a/tests/unit/semantic_release/version/test_version.py
+++ b/tests/unit/semantic_release/version/test_version.py
@@ -1,0 +1,42 @@
+import pytest
+
+from semantic_release.enums import LevelBump
+from semantic_release.version.version import Version
+
+
+@pytest.mark.parametrize(
+    "version_str, bump, is_prerelease, new_version_str",
+    [
+        ("1.0.0", LevelBump.MAJOR, False, "2.0.0"),
+        ("1.0.0", LevelBump.MINOR, False, "1.1.0"),
+        ("1.0.0", LevelBump.PATCH, False, "1.0.1"),
+        ("1.0.0", LevelBump.NO_RELEASE, False, "1.0.0"),
+        ("1.0.0", LevelBump.MAJOR, True, "2.0.0-rc.1"),
+        ("1.0.0", LevelBump.MINOR, True, "1.1.0-rc.1"),
+        ("1.0.0", LevelBump.PATCH, True, "1.0.1-rc.1"),
+        ("1.0.0", LevelBump.NO_RELEASE, True, "1.0.0"),
+        ("1.0.0-rc.1", LevelBump.MAJOR, False, "2.0.0"),
+        ("1.0.0-rc.1", LevelBump.MINOR, False, "1.1.0"),
+        ("1.0.0-rc.1", LevelBump.PATCH, False, "1.0.1"),
+        ("1.0.0-rc.1", LevelBump.NO_RELEASE, False, "1.0.0-rc.1"),
+        ("1.0.0-rc.1", LevelBump.MAJOR, True, "1.0.0-rc.2"),
+        ("1.0.0-rc.1", LevelBump.MINOR, True, "1.0.0-rc.2"),
+        ("1.0.0-rc.1", LevelBump.PATCH, True, "1.0.0-rc.2"),
+        ("1.0.0-rc.1", LevelBump.NO_RELEASE, True, "1.0.0-rc.1"),
+        # Note: currently build metadata isn't supported, this just
+        # documents expected behaviour
+        ("1.0.0+build.12345", LevelBump.MAJOR, False, "2.0.0"),
+        ("1.0.0+build.12345", LevelBump.MINOR, False, "1.1.0"),
+        ("1.0.0+build.12345", LevelBump.PATCH, False, "1.0.1"),
+        ("1.0.0+build.12345", LevelBump.NO_RELEASE, False, "1.0.0+build.12345"),
+        ("1.0.0+build.12345", LevelBump.MAJOR, True, "2.0.0-rc.1"),
+        ("1.0.0+build.12345", LevelBump.MINOR, True, "1.1.0-rc.1"),
+        ("1.0.0+build.12345", LevelBump.PATCH, True, "1.0.1-rc.1"),
+        ("1.0.0+build.12345", LevelBump.NO_RELEASE, True, "1.0.0+build.12345"),
+    ]
+)
+def test_version_bump(version_str, bump, is_prerelease, new_version_str):
+    version = Version.parse(version_str)
+    new_version = version.bump(bump, prerelease=is_prerelease, prerelease_token="rc")
+    assert version is not new_version, "Version.bump should return a new Version instance"
+    assert str(new_version) == new_version_str


### PR DESCRIPTION
This is the last required piece to implement the previous `get_next_version` method based on conventional commits. The method added enables a specific "bump" to the version based on the maximum level parsed from the commits since the last release (`version_history(...)[0]` -> `translator.to_tag(...)` -> `CommitStream(...)[version :]` -> `max(r.bump for r in stream if type(r) is ParsedCommit)`).
The rules are:
* If no release, the version is unchanged `1.0.0 -> 1.0.0`
* If already a pre-release version and doing a pre-release, increment the prerelease revision number `1.0.0-rc.1 -> 1.0.0-rc.2`
* If already a prerelease but doing a non-prerelease, finalize the version `1.0.0-rc.1 -> 1.0.0`
* If not a prerelease but doing a prerelease, bump by the specified level and add a prerelease token + revision number 1. `1.0.0  -> 1.1.0-rc.1`
* If not a prerelease and not doing a prerelease, bump by the specified level. `1.0.0 -> 1.1.0`