### PR TITLE
psr8-19 | Refactor hvcs client implementations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[tool.pytest.ini_options]
+addopts = ["-ra", "--cache-clear", "--cov=semantic_release", "--cov-report", "html:coverage-html", "--cov-report", "term"]
+python_files = ["tests/test_*.py", "tests/**/test_*.py"]

--- a/semantic_release/hvcs/_base.py
+++ b/semantic_release/hvcs/_base.py
@@ -1,0 +1,89 @@
+import logging
+import os
+from typing import Optional, Union, Tuple
+
+from requests import Session
+from urllib3 import Retry
+
+from semantic_release.helpers import parse_git_url
+from semantic_release.hvcs.token_auth import TokenAuth
+from semantic_release.hvcs.util import build_requests_session
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument
+class HvcsBase:
+    def __init__(
+        self,
+        remote_url: str,
+        hvcs_domain: Optional[str] = None,
+        hvcs_api_domain: Optional[str] = None,
+        token_var: str = "",
+    ) -> None:
+        self.hvcs_domain = hvcs_domain
+        self.hvcs_api_domain = hvcs_api_domain
+        self.token = os.getenv(token_var)
+        auth = TokenAuth(self.token)
+        self._remote_url = remote_url
+        self.session = build_requests_session(auth=auth)
+
+    def _get_repository_owner_and_name(self) -> Tuple[str, str]:
+        parsed_git_url = parse_git_url(self._remote_url)
+        return parsed_git_url.namespace, parsed_git_url.repo_name
+
+    @property
+    def repo_name(self) -> str:
+        _, _name = self._get_repository_owner_and_name()
+        return _name
+
+    @property
+    def owner(self) -> str:
+        _owner, _ = self._get_repository_owner_and_name()
+        return _owner
+
+    def compare_url(self, from_rev: str, to_rev: str) -> str:
+        """
+        Get the comparison link between two version tags.
+        :param from_rev: The older version to compare. Can be a commit sha, tag or branch name.
+        :param to_rev: The newer version to compare. Can be a commit sha, tag or branch name.
+        :return: Link to view a comparison between the two versions.
+        """
+        raise NotImplementedError()
+
+    def check_build_status(self, ref: str) -> bool:
+        raise NotImplementedError()
+
+    def upload_dists(self, release_id: str, path: str) -> bool:
+        # release_id is generally just the tag
+        # Skip on unsupported HVCS instead of raising error
+        return True
+
+    def create_release(self, tag: str, changelog: str, prerelease: bool = False) -> bool:
+        raise NotImplementedError()
+
+    def get_release_id_by_tag(self, tag: str) -> Optional[int]:
+        raise NotImplementedError()
+
+    def edit_release_changelog(self, release_id: int, changelog: str) -> bool:
+        raise NotImplementedError()
+
+    def create_or_update_release(
+        self, tag: str, changelog: str
+    ) -> bool:
+        raise NotImplementedError()
+
+    def asset_upload_url(self, release_id: str) -> Optional[str]:
+        raise NotImplementedError()
+
+    def upload_asset(self, release_id: int, file: str, label: Optional[str] = None) -> bool:
+        raise NotImplementedError()
+
+    def remote_url(self, use_token: bool) -> str:
+        raise NotImplementedError()
+
+    def commit_hash_url(self, commit_hash: str) -> str:
+        raise NotImplementedError()
+
+    def pull_request_url(self, pr_number: str) -> str:
+        raise NotImplementedError()

--- a/semantic_release/hvcs/gitea.py
+++ b/semantic_release/hvcs/gitea.py
@@ -1,0 +1,242 @@
+import logging
+import mimetypes
+import os
+from typing import Optional, Union
+
+from requests import Session
+from urllib3 import Retry
+
+from semantic_release.helpers import logged_function
+from semantic_release.hvcs._base import HvcsBase
+from semantic_release.hvcs.util import build_requests_session, suppress_http_error, suppress_not_found
+from semantic_release.hvcs.token_auth import TokenAuth
+
+logger = logging.getLogger(__name__)
+
+# Add a mime type for wheels
+# Fix incorrect entries in the `mimetypes` registry.
+# On Windows, the Python standard library's `mimetypes` reads in
+# mappings from file extension to MIME type from the Windows
+# registry. Other applications can and do write incorrect values
+# to this registry, which causes `mimetypes.guess_type` to return
+# incorrect values, which causes TensorBoard to fail to render on
+# the frontend.
+# This method hard-codes the correct mappings for certain MIME
+# types that are known to be either used by python-semantic-release or
+# problematic in general.
+mimetypes.add_type("application/octet-stream", ".whl")
+mimetypes.add_type("text/markdown", ".md")
+
+
+class Gitea(HvcsBase):
+    """Gitea helper class"""
+
+    DEFAULT_DOMAIN = "gitea.com"
+    DEFAULT_API_PATH = "/api/v1"
+    DEFAULT_API_DOMAIN = f"{DEFAULT_DOMAIN}{DEFAULT_API_PATH}"
+
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        remote_url: str,
+        hvcs_domain: Optional[str] = None,
+        hvcs_api_domain: Optional[str] = None,
+        token_var: str = "GITEA_TOKEN",
+    ) -> None:
+
+        self._remote_url = remote_url
+
+        self.hvcs_domain = hvcs_domain or os.getenv(
+            "GITEA_SERVER_URL", self.DEFAULT_DOMAIN
+        ).replace("https://", "")
+
+        self.hvcs_api_domain = hvcs_api_domain or os.getenv(
+            "GITEA_API_URL", self.DEFAULT_API_DOMAIN
+        ).replace("https://", "")
+
+        self.api_url = f"https://{self.hvcs_api_domain}"
+
+        self.token = os.getenv(token_var)
+        auth = None if not self.token else TokenAuth(self.token)
+        self.session = build_requests_session(auth=auth)
+
+    @logged_function(logger)
+    @suppress_http_error
+    def check_build_status(self, ref: str) -> bool:
+        """Check build status
+        https://gitea.com/api/swagger#/repository/repoCreateStatus
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param ref: The sha1 hash of the commit ref
+        :return: Was the build status success?
+        """
+        url = f"{self.api_url}/repos/{self.owner}/{self.repo_name}/statuses/{ref}"
+        response = self.session.get(url)
+        data = response.json()
+        if isinstance(data, list):
+            return data[0].get("status") == "success"
+        return data.get("status") == "success"
+
+    @logged_function(logger)
+    @suppress_http_error
+    def create_release(
+        self, tag: str, changelog: str, prerelease: bool = False
+    ) -> bool:
+        """Create a new release
+        https://gitea.com/api/swagger#/repository/repoCreateRelease
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param tag: Tag to create release for
+        :param changelog: The release notes for this version
+        :return: Whether the request succeeded
+        """
+        self.session.post(
+            f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases",
+            json={
+                "tag_name": tag,
+                "name": tag,
+                "body": changelog,
+                "draft": False,
+                "prerelease": prerelease,
+            },
+        )
+        return True
+
+    @logged_function(logger)
+    @suppress_not_found
+    def get_release_id_by_tag(self, tag: str) -> Optional[int]:
+        """Get a release by its tag name
+        https://gitea.com/api/swagger#/repository/repoGetReleaseByTag
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param tag: Tag to get release for
+        :return: ID of found release
+        """
+        response = self.session.get(
+            f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases/tags/{tag}"
+        )
+        return response.json().get("id")
+
+    @logged_function(logger)
+    @suppress_http_error
+    def edit_release_changelog(self, release_id: int, changelog: str) -> bool:
+        """Edit a release with updated change notes
+        https://gitea.com/api/swagger#/repository/repoEditRelease
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param id: ID of release to update
+        :param changelog: The release notes for this version
+        :return: Whether the request succeeded
+        """
+        self.session.patch(
+            f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases/{release_id}",
+            json={"body": changelog},
+        )
+        return True
+
+    @logged_function(logger)
+    def create_or_update_release(self, tag: str, changelog: str) -> bool:
+        """Post release changelog
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param version: The version number
+        :param changelog: The release notes for this version
+        :return: The status of the request
+        """
+        logger.debug("Attempting to create release for %s", tag)
+        success = self.create_release(tag, changelog)
+
+        if not success:
+            logger.debug("Unsuccessful, looking for an existing release to update")
+            release_id = self.get_release_id_by_tag(tag)
+            if release_id:
+                logger.debug("Updating release %d", release_id)
+                success = self.edit_release_changelog(release_id, changelog)
+            else:
+                logger.debug("Existing release not found")
+
+        return success
+
+    @logged_function(logger)
+    def asset_upload_url(self, release_id: str) -> str:
+        """Get the correct upload url for a release
+        https://gitea.com/api/swagger#/repository/repoCreateReleaseAttachment
+        :param release_id: ID of the release to upload to
+        """
+        return f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases/{release_id}/assets"
+
+    @logged_function(logger)
+    @suppress_http_error
+    def upload_asset(
+        self, release_id: int, file: str, label: Optional[str] = None
+    ) -> bool:
+        """Upload an asset to an existing release
+        https://gitea.com/api/swagger#/repository/repoCreateReleaseAttachment
+        :param release_id: ID of the release to upload to
+        :param file: Path of the file to upload
+        :param label: this parameter has no effect
+        :return: The status of the request
+        """
+        url = self.asset_upload_url(release_id)
+
+        with open(file, "rb") as attachment:
+            name = os.path.basename(file)
+            content_type = "application/octet-stream"
+            response = self.session.post(
+                url,
+                params={"name": name},
+                data={},
+                files={
+                    "attachment": (
+                        name,
+                        attachment,
+                        content_type,
+                    ),
+                },
+            )
+
+        logger.debug(
+            "Asset upload on Gitea completed, url: %s, status code: %d",
+            response.url,
+            response.status_code,
+        )
+
+        return True
+
+    @logged_function(logger)
+    def upload_dists(self, tag: str, path: str) -> bool:
+        """Upload distributions to a release
+        :param tag: Tag to upload for
+        :param path: Path to the dist directory
+        :return: The status of the request
+        """
+
+        # Find the release corresponding to this tag
+        release_id = self.get_release_id_by_tag(tag=tag)
+        if not release_id:
+            logger.debug("No release found to upload assets to")
+            return False
+
+        # Upload assets
+        all_succeeded = True
+        for file_path in (
+            os.path.join(path, file)
+            for file in os.listdir(path)
+            if os.path.isfile(os.path.join(path, file))
+        ):
+            all_succeeded &= self.upload_asset(release_id, file_path)
+
+        return all_succeeded
+
+    def remote_url(self, use_token: bool = True) -> str:
+        if not (self.token and use_token):
+            return self._remote_url
+        return (
+            f"https://{self.token}@{self.hvcs_domain}/{self.owner}/{self.repo_name}.git"
+        )
+
+    def commit_hash_url(self, commit_hash: str) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/commit/{commit_hash}"
+
+    def pull_request_url(self, pr_number: Union[str, int]) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/pulls/{pr_number}"

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -191,8 +191,6 @@ class Github(HvcsBase):
     def asset_upload_url(self, release_id: str) -> str:
         """Get the correct upload url for a release
         https://docs.github.com/en/enterprise-server@3.5/rest/releases/releases#get-a-release
-        :param owner: The owner namespace of the repository
-        :param repo_name The repository name
         :param release_id: ID of the release to upload to
         :return: URL found to upload for a release
         """
@@ -204,8 +202,6 @@ class Github(HvcsBase):
     def upload_asset(self, release_id: int, file: str, label: str = None) -> bool:
         """Upload an asset to an existing release
         https://docs.github.com/rest/reference/repos#upload-a-release-asset
-        :param owner: The owner namespace of the repository
-        :param repo_name The repository name
         :param release_id: ID of the release to upload to
         :param file: Path of the file to upload
         :param label: Custom label for this file
@@ -245,7 +241,7 @@ class Github(HvcsBase):
         """
 
         # Find the release corresponding to this version
-        release_id = self.get_release_id_by_tag(ref=tag)
+        release_id = self.get_release_id_by_tag(tag=tag)
         if not release_id:
             logger.debug("No release found to upload assets to")
             return False

--- a/semantic_release/hvcs/github.py
+++ b/semantic_release/hvcs/github.py
@@ -1,0 +1,267 @@
+import logging
+import mimetypes
+import os
+from typing import Optional, Union, Tuple
+
+from semantic_release.helpers import logged_function
+from semantic_release.hvcs._base import HvcsBase
+from semantic_release.hvcs.util import (
+    suppress_http_error,
+    suppress_not_found,
+    build_requests_session,
+)
+from semantic_release.hvcs.token_auth import TokenAuth
+
+
+logger = logging.getLogger(__name__)
+
+# Add a mime type for wheels
+mimetypes.add_type("application/octet-stream", ".whl")
+mimetypes.add_type("text/markdown", ".md")
+
+
+class Github(HvcsBase):
+    """Github helper class"""
+
+    DEFAULT_DOMAIN = "github.com"
+    DEFAULT_API_DOMAIN = "api.github.com"
+
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        remote_url: str,
+        hvcs_domain: Optional[str] = None,
+        hvcs_api_domain: Optional[str] = None,
+        token_var: str = "GH_TOKEN",
+    ) -> None:
+
+        # pylint: disable=line-too-long
+        # ref: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+        self.hvcs_domain = hvcs_domain or os.getenv(
+            "GITHUB_SERVER_URL", self.DEFAULT_DOMAIN
+        ).replace("https://", "")
+
+        # not necessarily prefixed with "api." in the case of a custom domain, so
+        # can't just default to "api.github.com"
+        # ref: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+        self.hvcs_api_domain = hvcs_api_domain or os.getenv(
+            "GITHUB_API_URL", self.DEFAULT_API_DOMAIN
+        ).replace("https://", "")
+
+        self.api_url = f"https://{self.hvcs_api_domain}"
+
+        self.token = os.getenv(token_var)
+        auth = None if not self.token else TokenAuth(self.token)
+        self._remote_url = remote_url
+        self.session = build_requests_session(auth=auth)
+
+    def _get_repository_owner_and_name(self) -> Tuple[str, str]:
+        # Github actions context
+        if "GITHUB_REPOSITORY" in os.environ:
+            owner, name = os.environ["GITHUB_REPOSITORY"].rsplit("/", 1)
+            return owner, name
+        return super()._get_repository_owner_and_name()
+
+    def compare_url(
+        self,
+        from_rev: str,
+        to_rev: str,
+    ) -> str:
+        """
+        Get the GitHub comparison link between two version tags.
+        :param from_rev: The older version to compare.
+        :param to_rev: The newer version to compare.
+        :return: Link to view a comparison between the two versions.
+        """
+        return (
+            f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/compare/"
+            f"{from_rev}...{to_rev}"
+        )
+
+    @logged_function(logger)
+    @suppress_http_error
+    def check_build_status(self, ref: str) -> bool:
+        """Check build status
+        https://docs.github.com/rest/reference/repos#get-the-combined-status-for-a-specific-reference
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param ref: The sha1 hash of the commit ref
+        :return: Was the build status success?
+        """
+        url = f"{self.api_url}/repos/{self.owner}/{self.repo_name}/commits/{ref}/status"
+        response = self.session.get(url)
+        return response.json().get("state") == "success"
+
+    @logged_function(logger)
+    @suppress_http_error
+    def create_release(
+        self, tag: str, changelog: str, prerelease: bool = False
+    ) -> bool:
+        """Create a new release
+        https://docs.github.com/rest/reference/repos#create-a-release
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param tag: Tag to create release for
+        :param changelog: The release notes for this version
+        :return: Whether the request succeeded
+        """
+        self.session.post(
+            f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases",
+            json={
+                "tag_name": tag,
+                "name": tag,
+                "body": changelog,
+                "draft": False,
+                "prerelease": prerelease,
+            },
+        )
+        return True
+
+    @logged_function(logger)
+    @suppress_not_found
+    def get_release_id_by_tag(self, tag: str) -> Optional[int]:
+        """Get a release by its tag name
+        https://docs.github.com/rest/reference/repos#get-a-release-by-tag-name
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param tag: Tag to get release for
+        :return: ID of found release
+        """
+        response = self.session.get(
+            f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases/tags/{tag}"
+        )
+        return response.json().get("id")
+
+    @logged_function(logger)
+    @suppress_http_error
+    def edit_release_changelog(
+        self,
+        release_id: int,
+        changelog: str,
+    ) -> bool:
+        """Edit a release with updated change notes
+        https://docs.github.com/rest/reference/repos#update-a-release
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param id: ID of release to update
+        :param changelog: The release notes for this version
+        :return: Whether the request succeeded
+        """
+        self.session.post(
+            f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases/{release_id}",
+            json={"body": changelog},
+        )
+        return True
+
+    @logged_function(logger)
+    def create_or_update_release(self, tag: str, changelog: str) -> bool:
+        """Post release changelog
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param version: The version number
+        :param changelog: The release notes for this version
+        :return: The status of the request
+        """
+        logger.debug("Attempting to create release for %s", tag)
+        success = self.create_release(tag, changelog)
+
+        if not success:
+            logger.debug("Unsuccessful, looking for an existing release to update")
+            release_id = self.get_release_id_by_tag(tag)
+            if release_id:
+                logger.debug("Updating release %d", release_id)
+                success = self.edit_release_changelog(release_id, changelog)
+            else:
+                logger.debug("Existing release not found")
+
+        return success
+
+    @logged_function(logger)
+    def asset_upload_url(self, release_id: str) -> str:
+        """Get the correct upload url for a release
+        https://docs.github.com/en/enterprise-server@3.5/rest/releases/releases#get-a-release
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param release_id: ID of the release to upload to
+        :return: URL found to upload for a release
+        """
+        # https://docs.github.com/en/enterprise-server@3.5/rest/releases/assets#upload-a-release-asset ?
+        return f"{self.api_url}/repos/{self.owner}/{self.repo_name}/releases/{release_id}/assets"
+
+    @logged_function(logger)
+    @suppress_http_error
+    def upload_asset(self, release_id: int, file: str, label: str = None) -> bool:
+        """Upload an asset to an existing release
+        https://docs.github.com/rest/reference/repos#upload-a-release-asset
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param release_id: ID of the release to upload to
+        :param file: Path of the file to upload
+        :param label: Custom label for this file
+        :return: The status of the request
+        """
+        url = self.asset_upload_url(release_id)
+        content_type = (
+            mimetypes.guess_type(file, strict=False)[0] or "application/octet-stream"
+        )
+
+        with open(file, "rb") as data:
+            response = self.session.post(
+                url,
+                params={"name": os.path.basename(file), "label": label},
+                headers={
+                    "Content-Type": content_type,
+                },
+                data=data.read(),
+            )
+
+        logger.debug(
+            "Asset upload on Github completed, url: %s, status code: %d",
+            response.url,
+            response.status_code,
+        )
+
+        return True
+
+    @logged_function(logger)
+    def upload_dists(self, tag: str, path: str) -> bool:
+        """Upload distributions to a release
+        :param owner: The owner namespace of the repository
+        :param repo_name The repository name
+        :param version: Version to upload for
+        :param path: Path to the dist directory
+        :return: The status of the request
+        """
+
+        # Find the release corresponding to this version
+        release_id = self.get_release_id_by_tag(ref=tag)
+        if not release_id:
+            logger.debug("No release found to upload assets to")
+            return False
+
+        # Upload assets
+        all_succeeded = True
+        for file_path in (
+            os.path.join(path, file)
+            for file in os.listdir(path)
+            if os.path.isfile(os.path.join(path, file))
+        ):
+            all_succeeded &= self.upload_asset(release_id, file_path)
+
+        return all_succeeded
+
+    def remote_url(self, use_token: bool = True) -> str:
+        if not (self.token and use_token):
+            return self._remote_url
+        actor = os.getenv("GITHUB_ACTOR")
+        return (
+            f"https://{actor}:{self.token}@{self.hvcs_domain}/{self.owner}/{self.repo_name}.git"
+            if actor
+            else f"https://{self.token}@{self.hvcs_domain}/{self.owner}/{self.repo_name}.git"
+        )
+
+    def commit_hash_url(self, commit_hash: str) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/commit/{commit_hash}"
+
+    def pull_request_url(self, pr_number: Union[str, int]) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/issues/{pr_number}"

--- a/semantic_release/hvcs/gitlab.py
+++ b/semantic_release/hvcs/gitlab.py
@@ -1,0 +1,146 @@
+import logging
+import mimetypes
+import os
+from typing import Optional, Tuple, Union
+from urllib.parse import urlsplit
+
+from gitlab import exceptions, gitlab
+
+from semantic_release.helpers import logged_function
+from semantic_release.hvcs._base import HvcsBase
+from semantic_release.hvcs.token_auth import TokenAuth
+from semantic_release.hvcs.util import build_requests_session
+
+logger = logging.getLogger(__name__)
+
+# Add a mime type for wheels
+# Fix incorrect entries in the `mimetypes` registry.
+# On Windows, the Python standard library's `mimetypes` reads in
+# mappings from file extension to MIME type from the Windows
+# registry. Other applications can and do write incorrect values
+# to this registry, which causes `mimetypes.guess_type` to return
+# incorrect values, which causes TensorBoard to fail to render on
+# the frontend.
+# This method hard-codes the correct mappings for certain MIME
+# types that are known to be either used by python-semantic-release or
+# problematic in general.
+mimetypes.add_type("application/octet-stream", ".whl")
+mimetypes.add_type("text/markdown", ".md")
+
+
+class Gitlab(HvcsBase):
+    """
+    Gitlab helper class
+    Note Gitlab doesn't really have the concept of a separate
+    API domain
+    """
+
+    DEFAULT_DOMAIN = "gitlab.com"
+
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        remote_url: str,
+        hvcs_domain: Optional[str] = None,
+        hvcs_api_domain: Optional[str] = None,
+        token_var: str = "GL_TOKEN",
+    ) -> None:
+        self._remote_url = remote_url
+        self.hvcs_domain = hvcs_domain or self._domain_from_environment() or self.DEFAULT_DOMAIN
+        self.hvcs_api_domain = hvcs_api_domain or self.hvcs_domain.replace("https://", "")
+        self.api_url = os.getenv("CI_SERVER_URL", f"https://{self.hvcs_api_domain}")
+
+        self.token = os.getenv(token_var)
+        auth = (
+            None if not self.token else TokenAuth(self.token)
+        )
+        self.session = build_requests_session(auth=auth)
+
+    @staticmethod
+    def _domain_from_environment() -> Optional[str]:
+        """
+        Use Gitlab-CI environment vars if available
+        """
+        if "CI_SERVER_URL" in os.environ:
+            url = urlsplit(os.environ["CI_SERVER_URL"])
+            return f"{url.netloc}{url.path}".rstrip("/")
+        return os.getenv("CI_SERVER_HOST")
+
+    def _get_repository_owner_and_name(self) -> Tuple[str, str]:
+        # Gitlab-CI context
+        if "CI_PROJECT_NAMESPACE" in os.environ and "CI_PROJECT_NAME" in os.environ:
+            return os.environ["CI_PROJECT_NAMESPACE"], os.environ["CI_PROJECT_NAME"]
+        return super()._get_repository_owner_and_name()
+
+    @logged_function(logger)
+    def check_build_status(self, ref: str) -> bool:
+        """Check last build status
+        :param owner: The owner namespace of the repository. It includes all groups and subgroups.
+        :param repo: The repository name
+        :param ref: The sha1 hash of the commit ref
+        :return: the status of the pipeline (False if a job failed)
+        """
+        client = gitlab.Gitlab(self.api_url, private_token=self.token)
+        client.auth()
+        jobs = (
+            client.projects.get(f"{self.owner}/{self.repo_name}")
+            .commits.get(ref)
+            .statuses.list()
+        )
+        for job in jobs:
+            # "success" and "skipped" aren't considered
+            if job["status"] == "pending":  # type: ignore[index]
+                logger.debug(
+                    "check_build_status: job %s is still in pending status",  # type: ignore[index]
+                    job["name"],
+                )
+                return False
+            if job["status"] == "failed" and not job["allow_failure"]:  # type: ignore[index]
+                logger.debug("check_build_status: job %s failed", job["name"])  # type: ignore[index]
+                return False
+        return True
+
+    @logged_function(logger)
+    def create_release(
+        self, tag: str, changelog: str
+    ) -> bool:
+        """Post release changelog
+        :param owner: The owner namespace of the repository
+        :param repo: The repository name
+        :param tag: Tag to create release for
+        :param changelog: The release notes for this version
+        :return: The status of the request
+        """
+        client = gitlab.Gitlab(self.api_url, private_token=self.token)
+        client.auth()
+        try:
+            logger.debug("Before release create call")
+            client.projects.get(self.owner + "/" + self.repo_name).releases.create(
+                {
+                    "name": "Release " + tag,
+                    "tag_name": tag,
+                    "description": changelog,
+                }
+            )
+            return True
+        except exceptions.GitlabCreateError:
+            logger.debug(
+                "Release %s could not be created for project %s/%s",
+                tag,
+                self.owner,
+                self.repo_name,
+            )
+            return False
+
+    def remote_url(self, use_token: bool = True) -> str:
+        if not (self.token and use_token):
+            return self._remote_url
+        return f"https://gitlab-ci-token:{self.token}@{self.hvcs_domain}/{self.owner}/{self.repo_name}.git"
+
+    def commit_hash_url(self, commit_hash: str) -> str:
+        return f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/commit/{commit_hash}"
+
+    def pull_request_url(self, pr_number: Union[str, int]) -> str:
+        return (
+            f"https://{self.hvcs_domain}/{self.owner}/{self.repo_name}/-/issues/{pr_number}"
+        )

--- a/semantic_release/hvcs/token_auth.py
+++ b/semantic_release/hvcs/token_auth.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from requests import Request
+from requests.auth import AuthBase
+
+
+class TokenAuth(AuthBase):
+    """
+    requests Authentication for token based authorization
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def __eq__(self, other: Any) -> bool:
+        return self.token == getattr(other, "token", None)
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __call__(self, req: Request) -> Request:
+        req.headers["Authorization"] = f"token {self.token}"
+        return req

--- a/semantic_release/hvcs/util.py
+++ b/semantic_release/hvcs/util.py
@@ -1,0 +1,87 @@
+import logging
+from functools import wraps
+from typing import Any, Optional, Callable, TypeVar, Union
+
+from requests import HTTPError, Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+from semantic_release.hvcs.token_auth import TokenAuth
+
+logger = logging.getLogger(__name__)
+
+
+def build_requests_session(
+    raise_for_status=True,
+    retry: Union[bool, int, Retry] = True,
+    auth: Optional[TokenAuth] = None,
+) -> Session:
+    """
+    Create a requests session.
+    :param raise_for_status: If True, a hook to invoke raise_for_status be installed
+    :param retry: If true, it will use default Retry configuration. if an integer, it will use default Retry
+    configuration with given integer as total retry count. if Retry instance, it will use this instance.
+    :return: configured requests Session
+    """
+    session = Session()
+    if raise_for_status:
+        session.hooks = {"response": [lambda r, *args, **kwargs: r.raise_for_status()]}
+
+    if retry:
+        if isinstance(retry, bool):
+            retry = Retry()
+        elif isinstance(retry, int):
+            retry = Retry(retry)
+        elif not isinstance(retry, Retry):
+            raise ValueError("retry should be a bool, int or Retry instance.")
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+    if auth:
+        session.auth = auth
+
+    return session
+
+
+def suppress_http_error(func: Callable[..., bool]) -> Callable[..., bool]:
+    @wraps(func)
+    def _wrapper(*a: Any, **kw: Any) -> bool:
+        try:
+            return func(*a, **kw)
+        except HTTPError as err:
+            logger.warning("%s failed: %s", func.__qualname__, err)
+            return False
+
+    return _wrapper
+
+
+_R = TypeVar("_R")
+
+
+def suppress_http_error_for_codes(
+    *codes: int,
+) -> Callable[[Callable[..., _R]], Callable[..., Optional[_R]]]:
+    def suppress_http_error_for_codes(
+        func: Callable[..., _R]
+    ) -> Callable[..., Optional[_R]]:
+        @wraps(func)
+        def _wrapper(*a: Any, **kw: Any) -> Optional[_R]:
+            try:
+                return func(*a, **kw)
+            except HTTPError as err:
+                if err.response.status_code in codes:
+                    logger.warning(
+                        "%s received response %d: %s",
+                        func.__qualname__,
+                        err.response.status_code,
+                        str(err),
+                    )
+                return None
+
+        return _wrapper
+
+    return suppress_http_error_for_codes
+
+
+suppress_not_found = suppress_http_error_for_codes(404)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [coverage:run]
 omit = */tests/*
 
-[tools:pytest]
-python_files = tests/test_*.py tests/**/test_*.py
+# [tools:pytest]
+# python_files = tests/test_*.py tests/**/test_*.py
 
 [isort]
 skip = .tox,venv

--- a/setup.py
+++ b/setup.py
@@ -55,15 +55,16 @@ setup(
     ],
     extras_require={
         "test": [
-            "coverage>=5,<6",
-            "pytest>=5,<6",
-            "pytest-xdist>=1,<2",
-            "pytest-mock>=2,<3",
+            "coverage>=6,<7",
+            "pytest>=7,<8",
+            "pytest-xdist>=2,<3",
+            "pytest-mock>=3,<4",
             "pytest-lazy-fixture~=0.6.3",
-            "responses==0.13.3",
-            "mock==1.3.0",
+            "pytest-cov>=4,<5",
+            "responses==0.21.0",
+            "requests-mock>=1.10.0,<2"
         ],
-        "docs": ["Sphinx==1.3.6", "Jinja2==3.0.3"],
+        "docs": ["Sphinx==5.2.3", "Jinja2==3.0.3"],
         "dev": ["tox", "isort", "black"],
         "mypy": ["mypy", "types-requests"],
     },

--- a/tests/const.py
+++ b/tests/const.py
@@ -376,3 +376,14 @@ setup(
     ],
 )
 """
+
+EXAMPLE_CHANGELOG_MD_CONTENT = r"""
+# CHANGELOG.md
+
+## This is an example changlog
+
+## v1.0.0
+* Various bugfixes, security enhancements
+* Extra cookies to enhance your experience
+* ~Removed~ simplified cookie opt-out handling logic
+"""

--- a/tests/fixtures/example_project.py
+++ b/tests/fixtures/example_project.py
@@ -8,6 +8,7 @@ from tests.const import (
     EXAMPLE_PYPROJECT_TOML_CONTENT,
     EXAMPLE_SETUP_PY_CONTENT,
     EXAMPLE_SETUP_CFG_CONTENT,
+    EXAMPLE_CHANGELOG_MD_CONTENT,
 )
 
 
@@ -40,6 +41,8 @@ def example_project(tmp_path):
     setup_cfg.write_text(EXAMPLE_SETUP_CFG_CONTENT)
     setup_py = tmp_path / "setup.py"
     setup_py.write_text(EXAMPLE_SETUP_PY_CONTENT)
+    changelog_md = tmp_path / "CHANGELOG.md"
+    changelog_md.write_text(EXAMPLE_CHANGELOG_MD_CONTENT)
     yield tmp_path
 
 
@@ -56,3 +59,8 @@ def example_setup_cfg(example_project):
 @pytest.fixture
 def example_setup_py(example_project):
     yield example_project / "setup.py"
+
+
+@pytest.fixture
+def example_changelog_md(example_project):
+    yield example_project / "CHANGELOG.md"

--- a/tests/fixtures/git_repo.py
+++ b/tests/fixtures/git_repo.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 from git import Repo, Actor
 
@@ -16,10 +17,20 @@ def file_in_repo():
     yield f"file-{shortuid()}.txt"
 
 
+@pytest.fixture
+def example_git_ssh_url():
+    yield f"git@example.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git"
+
+
+@pytest.fixture
+def example_git_https_url():
+    yield f"https://example.com/{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}"
+
+
 @pytest.fixture(
     params=[
-        f"git@example.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
-        f"https://example.com/{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}",
+        lazy_fixture("example_git_ssh_url"),
+        lazy_fixture("example_git_https_url")
     ]
 )
 def git_repo_factory(request, example_project):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,6 +1,8 @@
 import secrets
 import string
+from contextlib import contextmanager
 from itertools import zip_longest
+from tempfile import NamedTemporaryFile
 from typing import Optional, List, Tuple
 
 from git import Repo
@@ -31,3 +33,18 @@ def diff_strings(str_a: str, str_b: str) -> Tuple[List[Tuple[int, str]], List[Tu
         if right is not None:
             added.append((pos, right))
     return deleted, added
+
+
+@contextmanager
+def netrc_file(machine: str) -> NamedTemporaryFile:
+    with NamedTemporaryFile("w") as netrc:
+        # Add these attributes to use in tests as source of truth
+        netrc.login_username = "username"
+        netrc.login_password = "password"
+
+        netrc.write(f"machine {machine}" + "\n")
+        netrc.write(f"login {netrc.login_username}" + "\n")
+        netrc.write(f"password {netrc.login_password}" + "\n")
+        netrc.flush()
+
+        yield netrc

--- a/tests/unit/semantic_release/hvcs/test__base.py
+++ b/tests/unit/semantic_release/hvcs/test__base.py
@@ -1,0 +1,50 @@
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from semantic_release.errors import HvcsRepoParseError
+from semantic_release.hvcs._base import HvcsBase
+
+from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER
+
+
+@pytest.mark.parametrize(
+    "remote_url, repo_name",
+    [
+        (lazy_fixture("example_git_ssh_url"), EXAMPLE_REPO_NAME),
+        (lazy_fixture("example_git_https_url"), EXAMPLE_REPO_NAME),
+        ("git@my.corp.custom.domain:very_serious/business.git", "business"),
+    ],
+)
+def test_get_repository_owner(remote_url, repo_name):
+    client = HvcsBase(remote_url)
+    assert client.repo_name == repo_name
+
+
+@pytest.mark.parametrize(
+    "remote_url, owner",
+    [
+        (lazy_fixture("example_git_ssh_url"), EXAMPLE_REPO_OWNER),
+        (lazy_fixture("example_git_https_url"), EXAMPLE_REPO_OWNER),
+        ("git@my.corp.custom.domain:very_serious/business.git", "very_serious"),
+    ],
+)
+def test_get_repository_name(remote_url, owner):
+    client = HvcsBase(remote_url)
+    assert client.owner == owner
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "a" * 25,
+        "https://a/b/c/d/.git",
+        "https://github.com/wrong",
+        "git@gitlab.com/somewhere",
+    ],
+)
+def test_hvcs_parse_error(bad_url):
+    client = HvcsBase(bad_url)
+    with pytest.raises(ValueError):
+        client.repo_name
+    with pytest.raises(ValueError):
+        client.owner

--- a/tests/unit/semantic_release/hvcs/test_gitea.py
+++ b/tests/unit/semantic_release/hvcs/test_gitea.py
@@ -1,0 +1,582 @@
+import base64
+import mimetypes
+import re
+import os
+from urllib.parse import urlencode
+from unittest import mock
+
+import pytest
+import requests_mock
+from requests import Session
+
+from semantic_release.hvcs.gitea import Gitea
+from semantic_release.hvcs.token_auth import TokenAuth
+from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER
+from tests.helper import netrc_file
+
+
+@pytest.fixture
+def default_gitea_client():
+    remote_url = f"git@gitea.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git"
+    yield Gitea(remote_url=remote_url)
+
+
+@pytest.mark.parametrize(
+    (
+        "patched_os_environ, hvcs_domain, hvcs_api_domain, token_var, "
+        "expected_hvcs_domain, expected_hvcs_api_domain, expected_token"
+    ),
+    [
+        ({}, None, None, "", Gitea.DEFAULT_DOMAIN, Gitea.DEFAULT_API_DOMAIN, None),
+        (
+            {"GITEA_SERVER_URL": "https://special.custom.server/vcs/"},
+            None,
+            None,
+            "",
+            "special.custom.server/vcs/",
+            Gitea.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GITEA_API_URL": "https://api.special.custom.server/"},
+            None,
+            None,
+            "",
+            Gitea.DEFAULT_DOMAIN,
+            "api.special.custom.server/",
+            None,
+        ),
+        (
+            {},
+            None,
+            None,
+            "GITEA_TOKEN",
+            Gitea.DEFAULT_DOMAIN,
+            Gitea.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GH_TOKEN": "abc123"},
+            None,
+            None,
+            "GITEA_TOKEN",
+            Gitea.DEFAULT_DOMAIN,
+            Gitea.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GL_TOKEN": "abc123"},
+            None,
+            None,
+            "GITEA_TOKEN",
+            Gitea.DEFAULT_DOMAIN,
+            Gitea.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GITEA_TOKEN": "aabbcc"},
+            None,
+            None,
+            "GITEA_TOKEN",
+            Gitea.DEFAULT_DOMAIN,
+            Gitea.DEFAULT_API_DOMAIN,
+            "aabbcc",
+        ),
+        (
+            {"PSR__GIT_TOKEN": "aabbcc"},
+            None,
+            None,
+            "PSR__GIT_TOKEN",
+            Gitea.DEFAULT_DOMAIN,
+            Gitea.DEFAULT_API_DOMAIN,
+            "aabbcc",
+        ),
+        (
+            {"GITEA_SERVER_URL": "https://special.custom.server/vcs/"},
+            "https://example.com",
+            None,
+            "",
+            "https://example.com",
+            Gitea.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GITEA_API_URL": "https://api.special.custom.server/"},
+            None,
+            "https://api.example.com",
+            "",
+            Gitea.DEFAULT_DOMAIN,
+            "https://api.example.com",
+            None,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "remote_url",
+    [
+        f"git@gitea.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+        f"https://gitea.com/{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+    ],
+)
+def test_gitea_client_init(
+    patched_os_environ,
+    hvcs_domain,
+    hvcs_api_domain,
+    token_var,
+    expected_hvcs_domain,
+    expected_hvcs_api_domain,
+    expected_token,
+    remote_url,
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        client = Gitea(
+            remote_url=remote_url,
+            hvcs_domain=hvcs_domain,
+            hvcs_api_domain=hvcs_api_domain,
+            token_var=token_var,
+        )
+
+        assert client.hvcs_domain == expected_hvcs_domain
+        assert client.hvcs_api_domain == expected_hvcs_api_domain
+        assert client.api_url == f"https://{client.hvcs_api_domain}"
+        assert client.token == expected_token
+        assert client._remote_url == remote_url
+        assert hasattr(client, "session") and isinstance(
+            getattr(client, "session", None), Session
+        )
+
+
+def test_gitea_get_repository_owner_and_name(default_gitea_client):
+    assert (
+        default_gitea_client._get_repository_owner_and_name()
+        == super(Gitea, default_gitea_client)._get_repository_owner_and_name()
+    )
+
+
+@pytest.mark.parametrize(
+    "use_token, token, _remote_url, expected",
+    [
+        (
+            False,
+            "",
+            "git@gitea.com:custom/example.git",
+            "git@gitea.com:custom/example.git",
+        ),
+        (
+            True,
+            "",
+            "git@gitea.com:custom/example.git",
+            "git@gitea.com:custom/example.git",
+        ),
+        (
+            False,
+            "aabbcc",
+            "git@gitea.com:custom/example.git",
+            "git@gitea.com:custom/example.git",
+        ),
+        (
+            True,
+            "aabbcc",
+            "git@gitea.com:custom/example.git",
+            "https://aabbcc@gitea.com/custom/example.git",
+        ),
+        (
+            False,
+            "aabbcc",
+            "git@gitea.com:custom/example.git",
+            "git@gitea.com:custom/example.git",
+        ),
+        (
+            True,
+            "aabbcc",
+            "git@gitea.com:custom/example.git",
+            "https://aabbcc@gitea.com/custom/example.git",
+        ),
+    ],
+)
+def test_remote_url(
+    default_gitea_client,
+    use_token,
+    token,
+    _remote_url,
+    expected
+):
+    default_gitea_client._remote_url = _remote_url
+    default_gitea_client.token = token
+    assert default_gitea_client.remote_url(use_token=use_token) == expected
+
+
+def test_commit_hash_url(default_gitea_client):
+    sha = "hashashash"
+    assert default_gitea_client.commit_hash_url(
+        sha
+    ) == "https://{domain}/{owner}/{repo}/commit/{sha}".format(
+        domain=default_gitea_client.hvcs_domain,
+        owner=default_gitea_client.owner,
+        repo=default_gitea_client.repo_name,
+        sha=sha,
+    )
+
+
+@pytest.mark.parametrize("pr_number", (420, "420"))
+def test_pull_request_url(default_gitea_client, pr_number):
+    assert default_gitea_client.pull_request_url(
+        pr_number=pr_number
+    ) == "https://{domain}/{owner}/{repo}/pulls/{pr_number}".format(
+        domain=default_gitea_client.hvcs_domain,
+        owner=default_gitea_client.owner,
+        repo=default_gitea_client.repo_name,
+        pr_number=pr_number,
+    )
+
+
+def test_asset_upload_url(default_gitea_client):
+    assert default_gitea_client.asset_upload_url(
+        release_id=420
+    ) == "https://{domain}/repos/{owner}/{repo}/releases/{release_id}/assets".format(
+        domain=default_gitea_client.hvcs_api_domain,
+        owner=default_gitea_client.owner,
+        repo=default_gitea_client.repo_name,
+        release_id=420,
+    )
+
+
+############
+# Tests which need http response mocking
+############
+
+
+gitea_matcher = re.compile(rf"^https://{Gitea.DEFAULT_DOMAIN}")
+gitea_api_matcher = re.compile(rf"^https://{Gitea.DEFAULT_API_DOMAIN}")
+
+
+@pytest.mark.parametrize(
+    "resp_payload, status_code, expected",
+    [
+        ({"status": "success"}, 200, True),
+        ({"status": "pending"}, 200, False),
+        ({"status": "failed"}, 200, False),
+        ([{"status": "success"}] * 2, 200, True),
+        ([{"status": "pending"}] * 2, 200, False),
+        ([{"status": "failed"}] * 2, 200, False),
+        ({}, 404, False),
+    ],
+)
+def test_check_build_status(default_gitea_client, resp_payload, status_code, expected):
+    ref = "refA"
+    with requests_mock.Mocker(session=default_gitea_client.session) as m:
+        m.register_uri(
+            "GET", gitea_api_matcher, json=resp_payload, status_code=status_code
+        )
+        assert default_gitea_client.check_build_status(ref) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "GET"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/statuses/{ref}".format(
+                api_url=default_gitea_client.api_url,
+                owner=default_gitea_client.owner,
+                repo_name=default_gitea_client.repo_name,
+                ref=ref,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [
+        (201, True),
+        (400, False),
+        (409, False),
+    ],
+)
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_release(default_gitea_client, status_code, prerelease, expected):
+    tag = "v1.0.0"
+    changelog = "# TODO: Changelog"
+    with requests_mock.Mocker(session=default_gitea_client.session) as m:
+        m.register_uri(
+            "POST", gitea_api_matcher, json={"status": "ok"}, status_code=status_code
+        )
+        assert default_gitea_client.create_release(tag, changelog, prerelease) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "POST"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/releases".format(
+                api_url=default_gitea_client.api_url,
+                owner=default_gitea_client.owner,
+                repo_name=default_gitea_client.repo_name,
+            )
+        )
+        assert m.last_request.json() == {
+            "tag_name": tag,
+            "name": tag,
+            "body": changelog,
+            "draft": False,
+            "prerelease": prerelease,
+        }
+
+
+@pytest.mark.parametrize(
+    "token", (None, "super-token")
+)
+def test_should_create_release_using_token_or_netrc(default_gitea_client, token):
+    default_gitea_client.token = token
+    default_gitea_client.session.auth = None if not token else TokenAuth(token)
+    tag = "v1.0.0"
+    changelog = "# TODO: Changelog"
+
+    # Note write netrc file with DEFAULT_DOMAIN not DEFAULT_API_DOMAIN as can't
+    # handle /api/v1 in file
+    with requests_mock.Mocker(session=default_gitea_client.session) as m, netrc_file(
+        machine=default_gitea_client.DEFAULT_DOMAIN
+    ) as netrc, mock.patch.dict(os.environ, {"NETRC": netrc.name}, clear=True):
+
+        m.register_uri("POST", gitea_api_matcher, json={}, status_code=201)
+        assert default_gitea_client.create_release(tag, changelog)
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "POST"
+        if not token:
+            assert {
+                "Authorization": "Basic "
+                + base64.encodebytes(
+                    f"{netrc.login_username}:{netrc.login_password}".encode()
+                ).decode("ascii").strip()
+            }.items() <= m.last_request.headers.items()
+        else:
+            assert {
+                "Authorization": f"token {token}"
+            }.items() <= m.last_request.headers.items()
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/releases".format(
+                api_url=default_gitea_client.api_url,
+                owner=default_gitea_client.owner,
+                repo_name=default_gitea_client.repo_name,
+            )
+        )
+        assert m.last_request.json() == {
+            "tag_name": tag,
+            "name": tag,
+            "body": changelog,
+            "draft": False,
+            "prerelease": False,
+        }
+
+
+def test_request_has_no_auth_header_if_no_token_or_netrc():
+    with mock.patch.dict(os.environ, {}, clear=True):
+        client = Gitea(remote_url="git@gitea.com:something/somewhere.git")
+
+        with requests_mock.Mocker(session=client.session) as m:
+            m.register_uri("POST", gitea_api_matcher, json={}, status_code=201)
+            assert client.create_release("v1.0.0", "# TODO: Changelog")
+            assert m.called
+            assert len(m.request_history) == 1
+            assert m.last_request.method == "POST"
+            assert (
+                m.last_request.url
+                == "{api_url}/repos/{owner}/{repo_name}/releases".format(
+                    api_url=client.api_url,
+                    owner=client.owner,
+                    repo_name=client.repo_name,
+                )
+            )
+            assert "Authorization" not in m.last_request.headers
+
+
+@pytest.mark.parametrize(
+    "resp_payload, status_code, expected",
+    [
+        ({"id": 420}, 200, 420),
+        ({}, 404, None),
+    ],
+)
+def test_get_release_id_by_tag(default_gitea_client, resp_payload, status_code, expected):
+    tag = "v1.0.0"
+    with requests_mock.Mocker(session=default_gitea_client.session) as m:
+        m.register_uri(
+            "GET", gitea_api_matcher, json=resp_payload, status_code=status_code
+        )
+        assert default_gitea_client.get_release_id_by_tag(tag) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "GET"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/releases/tags/{tag}".format(
+                api_url=default_gitea_client.api_url,
+                owner=default_gitea_client.owner,
+                repo_name=default_gitea_client.repo_name,
+                tag=tag,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [
+        (201, True),
+        (400, False),
+        (404, False),
+        (429, False),
+        (500, False),
+        (503, False),
+    ],
+)
+def test_edit_release_changelog(default_gitea_client, status_code, expected):
+    release_id = 420
+    changelog = "# TODO: Changelog"
+    with requests_mock.Mocker(session=default_gitea_client.session) as m:
+        m.register_uri("PATCH", gitea_api_matcher, json={}, status_code=status_code)
+        assert default_gitea_client.edit_release_changelog(420, changelog) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "PATCH"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/releases/{release_id}".format(
+                api_url=default_gitea_client.api_url,
+                owner=default_gitea_client.owner,
+                repo_name=default_gitea_client.repo_name,
+                release_id=release_id,
+            )
+        )
+        assert m.last_request.json() == {"body": changelog}
+
+
+# Note - mocking as the logic for the create/update of a release
+# is covered by testing above, no point re-testing.
+@pytest.mark.parametrize(
+    "create_release_success, release_id, edit_release_success, expected",
+    [
+        (True, 420, True, True),
+        (True, 420, False, True),
+        (False, 420, True, True),
+        (False, 420, False, False),
+        (False, None, True, False),
+        (False, None, False, False),
+    ],
+)
+def test_create_or_update_release(
+    default_gitea_client,
+    create_release_success,
+    release_id,
+    edit_release_success,
+    expected,
+):
+    tag = "v1.0.0"
+    changelog = "# TODO: Changelog"
+    with mock.patch.object(
+        default_gitea_client, "create_release"
+    ) as mock_create_release, mock.patch.object(
+        default_gitea_client, "get_release_id_by_tag"
+    ) as mock_get_release_id_by_tag, mock.patch.object(
+        default_gitea_client, "edit_release_changelog"
+    ) as mock_edit_release_changelog:
+        mock_create_release.return_value = create_release_success
+        mock_get_release_id_by_tag.return_value = release_id
+        mock_edit_release_changelog.return_value = edit_release_success
+        # client = Gitea(remote_url="git@gitea.com:something/somewhere.git")
+        assert default_gitea_client.create_or_update_release(tag, changelog) == expected
+        mock_create_release.assert_called_once_with(tag, changelog)
+        if not create_release_success:
+            mock_get_release_id_by_tag.assert_called_once_with(tag)
+        if not create_release_success and release_id:
+            mock_edit_release_changelog.assert_called_once_with(release_id, changelog)
+        elif not create_release_success and not release_id:
+            mock_edit_release_changelog.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [
+        (201, True),
+        (400, False),
+        (500, False),
+        (503, False),
+    ],
+)
+def test_upload_asset(default_gitea_client, example_changelog_md, status_code, expected):
+    release_id = 420
+    urlparams = {"name": example_changelog_md.name}
+    with requests_mock.Mocker(session=default_gitea_client.session) as m:
+        m.register_uri(
+            "POST", gitea_api_matcher, json={"status": "ok"}, status_code=status_code
+        )
+        assert (
+            default_gitea_client.upload_asset(
+                release_id=release_id, file=example_changelog_md.resolve(), label="doesn't matter could be None"
+            )
+            == expected
+        )
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "POST"
+        assert m.last_request.url == "{url}?{params}".format(
+            url=default_gitea_client.asset_upload_url(release_id),
+            params=urlencode(urlparams),
+        )
+
+        # TODO: this feels brittle
+        changelog_text = m.last_request.body.split(b"\r\n")[4]
+        assert changelog_text == example_changelog_md.read_bytes()
+
+
+# Note - mocking as the logic for uploading an asset
+# is covered by testing above, no point re-testing.
+def test_upload_dists_when_release_id_not_found(default_gitea_client):
+    tag = "v1.0.0"
+    path = "doesn't matter"
+    with mock.patch.object(
+        default_gitea_client, "get_release_id_by_tag"
+    ) as mock_get_release_id_by_tag, mock.patch.object(
+        default_gitea_client, "upload_asset"
+    ) as mock_upload_asset:
+        mock_get_release_id_by_tag.return_value = None
+        assert not default_gitea_client.upload_dists(tag, path)
+        mock_get_release_id_by_tag.assert_called_once_with(tag=tag)
+        mock_upload_asset.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "files, upload_statuses, expected",
+    [
+        (["foo.zip", "bar.whl"], [True, False], False),
+        (["foo.whl", "foo.egg", "foo.tar.gz"], [True, True, True], True),
+        # What if not built?
+        ([], [], True),
+        # What if wrong directory/other stuff in output dir/subfolder?
+        (["specialconfig.yaml", "something.whl", "desc.md"], [True, True, True], True),
+    ],
+)
+def test_upload_dists_when_release_id_found(
+    default_gitea_client, files, upload_statuses, expected
+):
+    release_id = 420
+    tag = "doesn't matter"
+    path = "doesn't matter"
+    with mock.patch.object(
+        default_gitea_client, "get_release_id_by_tag"
+    ) as mock_get_release_id_by_tag, mock.patch.object(
+        default_gitea_client, "upload_asset"
+    ) as mock_upload_asset, mock.patch.object(
+        os, "listdir"
+    ) as mock_os_listdir, mock.patch.object(
+        os.path, "isfile"
+    ) as mock_os_path_isfile:
+        # Skip check as the filenames deliberately don't exists for testing
+        mock_os_path_isfile.return_value = True
+        mock_os_listdir.return_value = files
+        mock_get_release_id_by_tag.return_value = release_id
+
+        mock_upload_asset.side_effect = upload_statuses
+        assert default_gitea_client.upload_dists(tag, path) == expected
+        mock_get_release_id_by_tag.assert_called_once_with(tag=tag)
+        assert [
+            mock.call(release_id, os.path.join(path, fn)) for fn in files
+        ] == mock_upload_asset.call_args_list

--- a/tests/unit/semantic_release/hvcs/test_github.py
+++ b/tests/unit/semantic_release/hvcs/test_github.py
@@ -1,0 +1,510 @@
+import mimetypes
+import re
+import os
+from urllib.parse import urlencode
+from unittest import mock
+
+import pytest
+import requests_mock
+from requests import Session
+
+from semantic_release.hvcs.github import Github
+from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER
+
+
+@pytest.fixture
+def default_gh_client():
+    remote_url = f"git@github.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git"
+    yield Github(remote_url=remote_url)
+
+
+@pytest.mark.parametrize(
+    (
+        "patched_os_environ, hvcs_domain, hvcs_api_domain, token_var, "
+        "expected_hvcs_domain, expected_hvcs_api_domain, expected_token"
+    ),
+    [
+        ({}, None, None, "", Github.DEFAULT_DOMAIN, Github.DEFAULT_API_DOMAIN, None),
+        (
+            {"GITHUB_SERVER_URL": "https://special.custom.server/vcs/"},
+            None,
+            None,
+            "",
+            "special.custom.server/vcs/",
+            Github.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GITHUB_API_URL": "https://api.special.custom.server/"},
+            None,
+            None,
+            "",
+            Github.DEFAULT_DOMAIN,
+            "api.special.custom.server/",
+            None,
+        ),
+        (
+            {},
+            None,
+            None,
+            "GH_TOKEN",
+            Github.DEFAULT_DOMAIN,
+            Github.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GH_TOKEN": "aabbcc"},
+            None,
+            None,
+            "GH_TOKEN",
+            Github.DEFAULT_DOMAIN,
+            Github.DEFAULT_API_DOMAIN,
+            "aabbcc",
+        ),
+        (
+            {"PSR__GIT_TOKEN": "aabbcc"},
+            None,
+            None,
+            "PSR__GIT_TOKEN",
+            Github.DEFAULT_DOMAIN,
+            Github.DEFAULT_API_DOMAIN,
+            "aabbcc",
+        ),
+        (
+            {"GITHUB_SERVER_URL": "https://special.custom.server/vcs/"},
+            "https://example.com",
+            None,
+            "",
+            "https://example.com",
+            Github.DEFAULT_API_DOMAIN,
+            None,
+        ),
+        (
+            {"GITHUB_API_URL": "https://api.special.custom.server/"},
+            None,
+            "https://api.example.com",
+            "",
+            Github.DEFAULT_DOMAIN,
+            "https://api.example.com",
+            None,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "remote_url",
+    [
+        f"git@github.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+        f"https://github.com/{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+    ],
+)
+def test_github_client_init(
+    patched_os_environ,
+    hvcs_domain,
+    hvcs_api_domain,
+    token_var,
+    expected_hvcs_domain,
+    expected_hvcs_api_domain,
+    expected_token,
+    remote_url,
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        client = Github(
+            remote_url=remote_url,
+            hvcs_domain=hvcs_domain,
+            hvcs_api_domain=hvcs_api_domain,
+            token_var=token_var,
+        )
+
+        assert client.hvcs_domain == expected_hvcs_domain
+        assert client.hvcs_api_domain == expected_hvcs_api_domain
+        assert client.api_url == f"https://{client.hvcs_api_domain}"
+        assert client.token == expected_token
+        assert client._remote_url == remote_url
+        assert hasattr(client, "session") and isinstance(
+            getattr(client, "session", None), Session
+        )
+
+
+@pytest.mark.parametrize(
+    "patched_os_environ, expected_owner, expected_name",
+    [
+        ({}, None, None),
+        ({"GITHUB_REPOSITORY": "path/to/repo/foo"}, "path/to/repo", "foo"),
+    ],
+)
+def test_github_get_repository_owner_and_name(
+    default_gh_client, patched_os_environ, expected_owner, expected_name
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        if expected_owner is None and expected_name is None:
+            assert (
+                default_gh_client._get_repository_owner_and_name()
+                == super(Github, default_gh_client)._get_repository_owner_and_name()
+            )
+        else:
+            assert default_gh_client._get_repository_owner_and_name() == (
+                expected_owner,
+                expected_name,
+            )
+
+
+def test_compare_url(default_gh_client):
+    assert default_gh_client.compare_url(
+        from_rev="revA", to_rev="revB"
+    ) == "https://{domain}/{owner}/{repo}/compare/revA...revB".format(
+        domain=default_gh_client.hvcs_domain,
+        owner=default_gh_client.owner,
+        repo=default_gh_client.repo_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "patched_os_environ, use_token, token, _remote_url, expected",
+    [
+        (
+            {"GITHUB_ACTOR": "foo"},
+            False,
+            "",
+            "git@github.com:custom/example.git",
+            "git@github.com:custom/example.git",
+        ),
+        (
+            {"GITHUB_ACTOR": "foo"},
+            True,
+            "",
+            "git@github.com:custom/example.git",
+            "git@github.com:custom/example.git",
+        ),
+        (
+            {},
+            False,
+            "aabbcc",
+            "git@github.com:custom/example.git",
+            "git@github.com:custom/example.git",
+        ),
+        (
+            {},
+            True,
+            "aabbcc",
+            "git@github.com:custom/example.git",
+            "https://aabbcc@github.com/custom/example.git",
+        ),
+        (
+            {"GITHUB_ACTOR": "foo"},
+            False,
+            "aabbcc",
+            "git@github.com:custom/example.git",
+            "git@github.com:custom/example.git",
+        ),
+        (
+            {"GITHUB_ACTOR": "foo"},
+            True,
+            "aabbcc",
+            "git@github.com:custom/example.git",
+            "https://foo:aabbcc@github.com/custom/example.git",
+        ),
+    ],
+)
+def test_remote_url(
+    default_gh_client,
+    patched_os_environ,
+    use_token,
+    token,
+    _remote_url,
+    expected,
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        default_gh_client._remote_url = _remote_url
+        default_gh_client.token = token
+        assert default_gh_client.remote_url(use_token=use_token) == expected
+
+
+def test_commit_hash_url(default_gh_client):
+    sha = "hashashash"
+    assert default_gh_client.commit_hash_url(
+        sha
+    ) == "https://{domain}/{owner}/{repo}/commit/{sha}".format(
+        domain=default_gh_client.hvcs_domain,
+        owner=default_gh_client.owner,
+        repo=default_gh_client.repo_name,
+        sha=sha,
+    )
+
+
+@pytest.mark.parametrize("pr_number", (420, "420"))
+def test_pull_request_url(default_gh_client, pr_number):
+    assert default_gh_client.pull_request_url(
+        pr_number=pr_number
+    ) == "https://{domain}/{owner}/{repo}/issues/{pr_number}".format(
+        domain=default_gh_client.hvcs_domain,
+        owner=default_gh_client.owner,
+        repo=default_gh_client.repo_name,
+        pr_number=pr_number,
+    )
+
+
+def test_asset_upload_url(default_gh_client):
+    assert default_gh_client.asset_upload_url(
+        release_id=420
+    ) == "https://{domain}/repos/{owner}/{repo}/releases/{release_id}/assets".format(
+        domain=default_gh_client.hvcs_api_domain,
+        owner=default_gh_client.owner,
+        repo=default_gh_client.repo_name,
+        release_id=420,
+    )
+
+
+############
+# Tests which need http response mocking
+############
+
+
+github_matcher = re.compile(r"^https://github.com")
+github_api_matcher = re.compile(r"^https://api.github.com")
+
+
+@pytest.mark.parametrize(
+    "resp_payload, status_code, expected",
+    [
+        ({"state": "success"}, 200, True),
+        ({"state": "pending"}, 200, False),
+        ({"state": "failed"}, 200, False),
+        ({"error": "not found"}, 404, False),
+        ({"error": "too many requests"}, 429, False),
+        ({"error": "internal error"}, 500, False),
+        ({"error": "temporarily unavailable"}, 503, False),
+    ],
+)
+def test_check_build_status(default_gh_client, resp_payload, status_code, expected):
+    ref = "refA"
+    with requests_mock.Mocker(session=default_gh_client.session) as m:
+        m.register_uri(
+            "GET", github_api_matcher, json=resp_payload, status_code=status_code
+        )
+        assert default_gh_client.check_build_status(ref) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "GET"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/commits/{ref}/status".format(
+                api_url=default_gh_client.api_url,
+                owner=default_gh_client.owner,
+                repo_name=default_gh_client.repo_name,
+                ref=ref,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [
+        (200, True),
+        (201, True),
+        (400, False),
+        (404, False),
+        (429, False),
+        (500, False),
+        (503, False),
+    ],
+)
+@pytest.mark.parametrize("prerelease", (True, False))
+def test_create_release(default_gh_client, status_code, prerelease, expected):
+    tag = "v1.0.0"
+    changelog = "# TODO: Changelog"
+    with requests_mock.Mocker(session=default_gh_client.session) as m:
+        m.register_uri(
+            "POST", github_api_matcher, json={"status": "ok"}, status_code=status_code
+        )
+        assert default_gh_client.create_release(tag, changelog, prerelease) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "POST"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/releases".format(
+                api_url=default_gh_client.api_url,
+                owner=default_gh_client.owner,
+                repo_name=default_gh_client.repo_name,
+            )
+        )
+        assert m.last_request.json() == {
+            "tag_name": tag,
+            "name": tag,
+            "body": changelog,
+            "draft": False,
+            "prerelease": prerelease,
+        }
+
+
+@pytest.mark.parametrize(
+    "resp_payload, status_code, expected",
+    [
+        ({"id": 420, "status": "success"}, 200, 420),
+        ({"error": "not found"}, 404, None),
+        ({"error": "too many requests"}, 429, None),
+        ({"error": "internal error"}, 500, None),
+        ({"error": "temporarily unavailable"}, 503, None),
+    ],
+)
+def test_get_release_id_by_tag(default_gh_client, resp_payload, status_code, expected):
+    tag = "v1.0.0"
+    with requests_mock.Mocker(session=default_gh_client.session) as m:
+        m.register_uri(
+            "GET", github_api_matcher, json=resp_payload, status_code=status_code
+        )
+        assert default_gh_client.get_release_id_by_tag(tag) == expected
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "GET"
+        assert (
+            m.last_request.url
+            == "{api_url}/repos/{owner}/{repo_name}/releases/tags/{tag}".format(
+                api_url=default_gh_client.api_url,
+                owner=default_gh_client.owner,
+                repo_name=default_gh_client.repo_name,
+                tag=tag,
+            )
+        )
+
+
+# Note - mocking as the logic for the create/update of a release
+# is covered by testing above, no point re-testing.
+@pytest.mark.parametrize(
+    "create_release_success, release_id, edit_release_success, expected",
+    [
+        (True, 420, True, True),
+        (True, 420, False, True),
+        (False, 420, True, True),
+        (False, 420, False, False),
+        (False, None, True, False),
+        (False, None, False, False),
+    ],
+)
+def test_edit_release_changelog(
+    default_gh_client,
+    create_release_success,
+    release_id,
+    edit_release_success,
+    expected,
+):
+    tag = "v1.0.0"
+    changelog = "# TODO: Changelog"
+    with mock.patch.object(
+        default_gh_client, "create_release"
+    ) as mock_create_release, mock.patch.object(
+        default_gh_client, "get_release_id_by_tag"
+    ) as mock_get_release_id_by_tag, mock.patch.object(
+        default_gh_client, "edit_release_changelog"
+    ) as mock_edit_release_changelog:
+        mock_create_release.return_value = create_release_success
+        mock_get_release_id_by_tag.return_value = release_id
+        mock_edit_release_changelog.return_value = edit_release_success
+        # client = Github(remote_url="git@github.com:something/somewhere.git")
+        assert default_gh_client.create_or_update_release(tag, changelog) == expected
+        mock_create_release.assert_called_once_with(tag, changelog)
+        if not create_release_success:
+            mock_get_release_id_by_tag.assert_called_once_with(tag)
+        if not create_release_success and release_id:
+            mock_edit_release_changelog.assert_called_once_with(release_id, changelog)
+        elif not create_release_success and not release_id:
+            mock_edit_release_changelog.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [
+        (200, True),
+        (201, True),
+        (400, False),
+        (404, False),
+        (429, False),
+        (500, False),
+        (503, False),
+    ],
+)
+def test_upload_asset(default_gh_client, example_changelog_md, status_code, expected):
+    release_id = 420
+    label = "abc123"
+    urlparams = {"name": example_changelog_md.name, "label": label}
+    with requests_mock.Mocker(session=default_gh_client.session) as m:
+        m.register_uri(
+            "POST", github_api_matcher, json={"status": "ok"}, status_code=status_code
+        )
+        assert (
+            default_gh_client.upload_asset(
+                release_id=release_id, file=example_changelog_md.resolve(), label=label
+            )
+            == expected
+        )
+        assert m.called
+        assert len(m.request_history) == 1
+        assert m.last_request.method == "POST"
+        assert m.last_request.url == "{url}?{params}".format(
+            url=default_gh_client.asset_upload_url(release_id),
+            params=urlencode(urlparams),
+        )
+
+        # Check if content-type header was correctly set
+        assert {
+            "Content-Type": mimetypes.guess_type(
+                example_changelog_md.resolve(), strict=False
+            )[0]
+            or "application/octet-stream"
+        }.items() <= m.last_request.headers.items()
+        assert m.last_request.body == example_changelog_md.read_bytes()
+
+
+# Note - mocking as the logic for uploading an asset
+# is covered by testing above, no point re-testing.
+def test_upload_dists_when_release_id_not_found(default_gh_client):
+    tag = "v1.0.0"
+    path = "doesn't matter"
+    with mock.patch.object(
+        default_gh_client, "get_release_id_by_tag"
+    ) as mock_get_release_id_by_tag, mock.patch.object(
+        default_gh_client, "upload_asset"
+    ) as mock_upload_asset:
+        mock_get_release_id_by_tag.return_value = None
+        assert not default_gh_client.upload_dists(tag, path)
+        mock_get_release_id_by_tag.assert_called_once_with(ref=tag)
+        mock_upload_asset.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "files, upload_statuses, expected",
+    [
+        (["foo.zip", "bar.whl"], [True, False], False),
+        (["foo.whl", "foo.egg", "foo.tar.gz"], [True, True, True], True),
+        # What if not built?
+        ([], [], True),
+        # What if wrong directory/other stuff in output dir/subfolder?
+        (["specialconfig.yaml", "something.whl", "desc.md"], [True, True, True], True),
+    ],
+)
+def test_upload_dists_when_release_id_found(
+    default_gh_client, files, upload_statuses, expected
+):
+    release_id = 420
+    tag = "doesn't matter"
+    path = "doesn't matter"
+    with mock.patch.object(
+        default_gh_client, "get_release_id_by_tag"
+    ) as mock_get_release_id_by_tag, mock.patch.object(
+        default_gh_client, "upload_asset"
+    ) as mock_upload_asset, mock.patch.object(
+        os, "listdir"
+    ) as mock_os_listdir, mock.patch.object(
+        os.path, "isfile"
+    ) as mock_os_path_isfile:
+        # Skip check as the filenames deliberately don't exists for testing
+        mock_os_path_isfile.return_value = True
+        mock_os_listdir.return_value = files
+        mock_get_release_id_by_tag.return_value = release_id
+
+        mock_upload_asset.side_effect = upload_statuses
+        assert default_gh_client.upload_dists(tag, path) == expected
+        mock_get_release_id_by_tag.assert_called_once_with(ref=tag)
+        assert [
+            mock.call(release_id, os.path.join(path, fn)) for fn in files
+        ] == mock_upload_asset.call_args_list

--- a/tests/unit/semantic_release/hvcs/test_gitlab.py
+++ b/tests/unit/semantic_release/hvcs/test_gitlab.py
@@ -1,0 +1,381 @@
+import os
+from contextlib import contextmanager
+from unittest import mock
+
+import gitlab
+import pytest
+from requests import Session
+
+from semantic_release.hvcs.gitlab import Gitlab
+from tests.const import EXAMPLE_REPO_NAME, EXAMPLE_REPO_OWNER
+
+
+gitlab.Gitlab("")  # instantiation necessary to discover gitlab ProjectManager
+
+# Note: there's nothing special about the value of these variables,
+# they're just constants for easier consistency with the faked objects
+A_GOOD_TAG = "v1.2.3"
+A_BAD_TAG = "v2.1.1-rc.1"
+A_LOCKED_TAG = "v0.9.0"
+# But note this is the only ref we're making a "fake" commit for, so
+# tests which need to query the remote for "a" ref, the exact sha for
+# which doesn't matter, all use this constant
+REF = "hashashash"
+
+
+class _GitlabProject:
+    def __init__(self, status):
+        self.commits = {REF: self._Commit(status)}
+        self.tags = self._Tags()
+        self.releases = self._Releases()
+
+    class _Commit:
+        def __init__(self, status):
+            self.statuses = self._Statuses(status)
+
+        class _Statuses:
+            def __init__(self, status):
+                if status == "pending":
+                    self.jobs = [
+                        {
+                            "name": "good_job",
+                            "status": "passed",
+                            "allow_failure": False,
+                        },
+                        {
+                            "name": "slow_job",
+                            "status": "pending",
+                            "allow_failure": False,
+                        },
+                    ]
+                elif status == "failure":
+                    self.jobs = [
+                        {
+                            "name": "good_job",
+                            "status": "passed",
+                            "allow_failure": False,
+                        },
+                        {"name": "bad_job", "status": "failed", "allow_failure": False},
+                    ]
+                elif status == "allow_failure":
+                    self.jobs = [
+                        {
+                            "name": "notsobad_job",
+                            "status": "failed",
+                            "allow_failure": True,
+                        },
+                        {
+                            "name": "good_job2",
+                            "status": "passed",
+                            "allow_failure": False,
+                        },
+                    ]
+                elif status == "success":
+                    self.jobs = [
+                        {
+                            "name": "good_job1",
+                            "status": "passed",
+                            "allow_failure": True,
+                        },
+                        {
+                            "name": "good_job2",
+                            "status": "passed",
+                            "allow_failure": False,
+                        },
+                    ]
+
+            def list(self):
+                return self.jobs
+
+    class _Tags:
+        def __init__(self):
+            pass
+
+        def get(self, tag):
+            if tag == A_GOOD_TAG:
+                return self._Tag()
+            elif tag == A_LOCKED_TAG:
+                return self._Tag(locked=True)
+            else:
+                raise gitlab.exceptions.GitlabGetError
+
+        class _Tag:
+            def __init__(self, locked=False):
+                self.locked = locked
+
+            def set_release_description(self, changelog):
+                if self.locked:
+                    raise gitlab.exceptions.GitlabUpdateError
+
+    class _Releases:
+        def __init__(self):
+            pass
+
+        def create(self, input_):
+            if input_["name"] and input_["tag_name"]:
+                if (
+                    input_["tag_name"] in (A_GOOD_TAG, A_LOCKED_TAG)
+                ):
+                    return self._Release()
+            raise gitlab.exceptions.GitlabCreateError
+
+        class _Release:
+            def __init__(self, locked=False):
+                pass
+
+
+@contextmanager
+def mock_gitlab(status: str = "success"):
+    with mock.patch("gitlab.Gitlab.auth"), mock.patch(
+            "gitlab.v4.objects.ProjectManager",
+            return_value={
+                f"{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}": _GitlabProject(status)
+            }
+    ):
+        yield
+
+
+@pytest.fixture
+def default_gl_client():
+    remote_url = f"git@gitlab.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git"
+    yield Gitlab(remote_url=remote_url)
+
+
+@pytest.mark.parametrize(
+    (
+        "patched_os_environ, hvcs_domain, hvcs_api_domain, token_var, "
+        "expected_hvcs_domain, expected_hvcs_api_domain, expected_token"
+    ),
+    [
+        ({}, None, None, "", Gitlab.DEFAULT_DOMAIN, Gitlab.DEFAULT_DOMAIN, None),
+        (
+            {"CI_SERVER_URL": "https://special.custom.server/vcs/"},
+            None,
+            None,
+            "",
+            "special.custom.server/vcs",
+            "special.custom.server/vcs",
+            None,
+        ),
+        (
+            {"CI_SERVER_HOST": "api.special.custom.server/"},
+            None,
+            None,
+            "",
+            "api.special.custom.server/",
+            "api.special.custom.server/",
+            None,
+        ),
+        (
+            {},
+            None,
+            None,
+            "GL_TOKEN",
+            Gitlab.DEFAULT_DOMAIN,
+            Gitlab.DEFAULT_DOMAIN,
+            None,
+        ),
+        (
+            {"GH_TOKEN": "abc123"},
+            None,
+            None,
+            "GL_TOKEN",
+            Gitlab.DEFAULT_DOMAIN,
+            Gitlab.DEFAULT_DOMAIN,
+            None,
+        ),
+        (
+            {"GITEA_TOKEN": "abc123"},
+            None,
+            None,
+            "GL_TOKEN",
+            Gitlab.DEFAULT_DOMAIN,
+            Gitlab.DEFAULT_DOMAIN,
+            None,
+        ),
+        (
+            {"GL_TOKEN": "aabbcc"},
+            None,
+            None,
+            "GL_TOKEN",
+            Gitlab.DEFAULT_DOMAIN,
+            Gitlab.DEFAULT_DOMAIN,
+            "aabbcc",
+        ),
+        (
+            {"PSR__GIT_TOKEN": "aabbcc"},
+            None,
+            None,
+            "PSR__GIT_TOKEN",
+            Gitlab.DEFAULT_DOMAIN,
+            Gitlab.DEFAULT_DOMAIN,
+            "aabbcc",
+        ),
+        (
+            {"CI_SERVER_URL": "https://special.custom.server/vcs/"},
+            "example.com",
+            None,
+            "",
+            "example.com",
+            "example.com",
+            None,
+        ),
+        (
+            {"CI_SERVER_URL": "https://api.special.custom.server/"},
+            None,
+            "api.example.com",
+            "",
+            "api.special.custom.server",
+            "api.example.com",
+            None,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "remote_url",
+    [
+        f"git@gitlab.com:{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+        f"https://gitlab.com/{EXAMPLE_REPO_OWNER}/{EXAMPLE_REPO_NAME}.git",
+    ],
+)
+def test_gitlab_client_init(
+    patched_os_environ,
+    hvcs_domain,
+    hvcs_api_domain,
+    token_var,
+    expected_hvcs_domain,
+    expected_hvcs_api_domain,
+    expected_token,
+    remote_url,
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        client = Gitlab(
+            remote_url=remote_url,
+            hvcs_domain=hvcs_domain,
+            hvcs_api_domain=hvcs_api_domain,
+            token_var=token_var,
+        )
+
+        assert client.hvcs_domain == expected_hvcs_domain
+        assert client.hvcs_api_domain == expected_hvcs_api_domain
+        assert client.api_url == patched_os_environ.get("CI_SERVER_URL", f"https://{client.hvcs_api_domain}")
+        assert client.token == expected_token
+        assert client._remote_url == remote_url
+        assert hasattr(client, "session") and isinstance(
+            getattr(client, "session", None), Session
+        )
+
+
+@pytest.mark.parametrize(
+    "patched_os_environ, expected_owner, expected_name",
+    [
+        ({}, None, None),
+        ({"CI_PROJECT_NAMESPACE": "path/to/repo", "CI_PROJECT_NAME": "foo"}, "path/to/repo", "foo"),
+    ],
+)
+def test_gitlab_get_repository_owner_and_name(
+    default_gl_client, patched_os_environ, expected_owner, expected_name
+):
+    with mock.patch.dict(os.environ, patched_os_environ, clear=True):
+        if expected_owner is None and expected_name is None:
+            assert (
+                default_gl_client._get_repository_owner_and_name()
+                == super(Gitlab, default_gl_client)._get_repository_owner_and_name()
+            )
+        else:
+            assert default_gl_client._get_repository_owner_and_name() == (
+                expected_owner,
+                expected_name,
+            )
+
+
+@pytest.mark.parametrize(
+    "use_token, token, _remote_url, expected",
+    [
+        (
+            False,
+            "",
+            "git@gitlab.com:custom/example.git",
+            "git@gitlab.com:custom/example.git",
+        ),
+        (
+            True,
+            "",
+            "git@gitlab.com:custom/example.git",
+            "git@gitlab.com:custom/example.git",
+        ),
+        (
+            False,
+            "aabbcc",
+            "git@gitlab.com:custom/example.git",
+            "git@gitlab.com:custom/example.git",
+        ),
+        (
+            True,
+            "aabbcc",
+            "git@gitlab.com:custom/example.git",
+            "https://gitlab-ci-token:aabbcc@gitlab.com/custom/example.git",
+        ),
+    ],
+)
+def test_remote_url(
+    default_gl_client,
+    use_token,
+    token,
+    _remote_url,
+    expected,
+):
+    default_gl_client._remote_url = _remote_url
+    default_gl_client.token = token
+    assert default_gl_client.remote_url(use_token=use_token) == expected
+
+
+def test_commit_hash_url(default_gl_client):
+    assert default_gl_client.commit_hash_url(
+        REF
+    ) == "https://{domain}/{owner}/{repo}/-/commit/{sha}".format(
+        domain=default_gl_client.hvcs_domain,
+        owner=default_gl_client.owner,
+        repo=default_gl_client.repo_name,
+        sha=REF,
+    )
+
+
+@pytest.mark.parametrize("pr_number", (420, "420"))
+def test_pull_request_url(default_gl_client, pr_number):
+    assert default_gl_client.pull_request_url(
+        pr_number=pr_number
+    ) == "https://{domain}/{owner}/{repo}/-/issues/{pr_number}".format(
+        domain=default_gl_client.hvcs_domain,
+        owner=default_gl_client.owner,
+        repo=default_gl_client.repo_name,
+        pr_number=pr_number,
+    )
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        ("pending", False),
+        ("failure", False),
+        ("allow_failure", True),
+        ("success", True)
+    ]
+)
+def test_check_build_status(default_gl_client, status, expected):
+    with mock_gitlab(status=status):
+        assert default_gl_client.check_build_status(REF) == expected
+
+
+@pytest.mark.parametrize(
+    "tag, expected",
+    [
+        (A_GOOD_TAG, True),
+        (A_LOCKED_TAG, True),
+        (A_BAD_TAG, False),
+    ],
+)
+def test_create_release(default_gl_client, tag, expected):
+    changelog = "# TODO: Changelog"
+    with mock_gitlab():
+        assert default_gl_client.create_release(tag, changelog) == expected

--- a/tests/unit/semantic_release/hvcs/test_token_auth.py
+++ b/tests/unit/semantic_release/hvcs/test_token_auth.py
@@ -1,0 +1,45 @@
+import pytest
+
+from requests import Request
+
+
+from semantic_release.hvcs.token_auth import TokenAuth
+
+
+@pytest.fixture
+def example_request():
+    yield Request(
+        "GET",
+        url="http://example.com",
+        headers={
+            "User-Agent": "Python3",
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+    )
+
+
+def test_token_eq():
+    t1 = TokenAuth("foo")
+    t2 = TokenAuth("foo")
+
+    assert t1 == t2
+
+
+def test_token_neq():
+    t1 = TokenAuth("foo")
+    t2 = TokenAuth("bar")
+
+    assert t1 != t2
+
+
+def test_call_token_auth_sets_headers(example_request):
+    old_headers = example_request.headers.copy()
+    old_headers.pop("Authorization", None)
+    t1 = TokenAuth("foo")
+    new_req = t1(example_request)
+
+    auth_header = new_req.headers.pop("Authorization")
+    assert auth_header == "token foo"
+    assert new_req.headers == old_headers
+    assert new_req.__dict__ == example_request.__dict__


### PR DESCRIPTION
Also includes a bump of project dependencies, and shift to pep517 build metadata.
Waiting to see if `responses` can be removed as `requests-mock` turned out easier to use in anger
