### PR TITLE
fix: fix bug in git url regular expression (GIT_URL_REGEX) for the sc…

### DIFF
--- a/semantic_release/helpers.py
+++ b/semantic_release/helpers.py
@@ -92,7 +92,7 @@ class ParsedGitUrl(NamedTuple):
 GIT_URL_REGEX = re.compile(
     r"""
     ^
-    git@
+    (?P<user>[\w\d\-.]+)@
     (?P<netloc>[^:]+)
     :
     (?P<namespace>[\w\.@\:/\-~]+)
@@ -139,7 +139,7 @@ def parse_git_url(url: str) -> ParsedGitUrl:
     if not all((*m.group("netloc", "namespace"), repo_name)):
         raise ValueError(f"Bad url: {url!r}")
     return ParsedGitUrl(
-        scheme="git",
+        scheme="ssh",
         netloc=m.group("netloc"),
         namespace=m.group("namespace"),
         repo_name=repo_name,


### PR DESCRIPTION
…p-like syntax for the ssh protocol

This pattern incorrectly expected the user name preceeding the at sign '@' to always be 'git'. However this could be any user name. see section '4.1 Git on the Server - The Protocols' at https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols