### PR TITLE
fix: psr8-59 | cleanup

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -139,9 +139,11 @@ These flags are optional but mutually exclusive, so only one may be supplied, or
 Using these flags overrides the usual calculation for the next version; this can be useful, say,
 when a project wants to release its initial 1.0.0 version.
 
-Using these flags will **not** produce a prerelease, **regardless of your configuration or the
-current version**. To produce a prerelease with the appropriate digit incremented you should also
-supply the :ref:`cmd-version-option-prerelease` flag.
+.. warning::
+    Using these flags will override the value of prerelease, **regardless of your configuration or the
+    current version**. To produce a prerelease with the appropriate digit incremented you should also
+    supply the :ref:`cmd-version-option-prerelease` flag. If you do not, using these flags will force
+    a full (non-prerelease) version to be created.
 
 These options are forceful overrides, but there is no action required for subsequent releases
 performed using the usual calculation algorithm.
@@ -159,8 +161,16 @@ Force the next version to be a prerelease. As with :ref:`cmd-version-option-forc
 is a forceful override, but no action is required to resume calculating versions as normal on the
 subsequent releases.
 
-The prerelease token is idenitified using the
+If not specified in :ref:`cmd-version-option-prerelease-token`, the prerelease token is idenitified using the
 :ref:`Multibranch Release Configuration <multibranch-releases-configuring>`
+
+.. _cmd-version-option-prerelease-token:
+
+``--prerelease-token [VALUE]``
+******************************
+
+Force the next version to use the value as the prerelease token. This overrides the configured value if one is
+present. If not used during a release producing a prerelease version, this option has no effect.
 
 .. _cmd-version-option-build-metadata:
 
@@ -285,7 +295,7 @@ your needs.
 For example, to append the default configuration to your pyproject.toml
 file, you can use the following command::
 
-    $ semantic-release generate-config -f toml >> pyproject.toml
+    $ semantic-release generate-config -f toml --pyproject >> pyproject.toml
 
 If your project doesn't already leverage TOML files for configuration, it might better
 suit your project to use JSON instead::
@@ -318,6 +328,18 @@ The format that the default configuration should be generated in. Valid choices 
 ``toml`` and ``json`` (case-insensitive).
 
 **Default:** toml
+
+.. _cmd-generate-config-option-pyproject:
+
+``--pyproject``
+***************
+
+If used alongside ``--format json``, this option has no effect. When using
+``--format=toml``, if specified the configuration will sit under a top-level key
+of ``tool.semantic_release`` to comply with `PEP 518`_; otherwise, the configuration
+will sit under a top-level key of ``semantic_release``.
+
+.. _PEP 518: https://peps.python.org/pep-0518/#tool-table
 
 
 .. _cmd-changelog:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,13 +38,13 @@ inspect the default configuration in your terminal by running
 
 ``semantic-release generate-config``
 
-You can also use the ``-f/--format`` option to specify what foramt you would like this configuration
+You can also use the :ref:`-f/--format <cmd-generate-config-option-format>` option to specify what foramt you would like this configuration
 to be. The default is TOML, but JSON can also be used.
 
 You can append the configuration to your existing ``pyproject.toml`` file using a standard redirect,
 for example:
 
-``semantic-release generate-config >> pyproject.toml``
+``semantic-release generate-config --pyproject >> pyproject.toml``
 
 and then editing to your project's requirements.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 semantic-release = "semantic_release.cli:main"
 
 [project.urls]
-"Project Url" = "http://github.com/relekang/python-semantic-release"
+"Project Url" = "http://github.com/python-semantic-release/python-semantic-release"
 Homepage = "https://python-semantic-release.readthedocs.io"
 
 [project.optional-dependencies]

--- a/semantic_release/cli/commands/generate_config.py
+++ b/semantic_release/cli/commands/generate_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import click
@@ -15,9 +17,13 @@ from semantic_release.cli.config import RawConfig
     default="toml",
     help="format for the config to be generated",
 )
-# A "--commit/--no-commit" option? Or is this better with the "--dry-run" flag?
-# how about push/no-push?
-def generate_config(fmt: str = "toml") -> None:
+@click.option(
+    "--pyproject",
+    "is_pyproject_toml",
+    is_flag=True,
+    help="Add TOML configuration under 'tool.semantic_release' instead of 'semantic_release'",
+)
+def generate_config(fmt: str = "toml", is_pyproject_toml: bool = False) -> None:
     """
     Generate default configuration for semantic-release, to help you get started
     quickly. You can inspect the defaults, write to a file and then edit according to
@@ -27,7 +33,13 @@ def generate_config(fmt: str = "toml") -> None:
         semantic-release generate-config -f toml >> pyproject.toml
     """
     config = RawConfig().dict(exclude_none=True)
+
+    config_dct = {"semantic_release": config}
+    if is_pyproject_toml and fmt == "toml":
+        config_dct = {"tool": config_dct}
+
     if fmt == "toml":
-        click.echo(tomlkit.dumps({"tool": {"semantic_release": config}}))
+        click.echo(tomlkit.dumps(config_dct))
+
     elif fmt == "json":
-        click.echo(json.dumps({"semantic_release": config}, indent=4))
+        click.echo(json.dumps(config_dct, indent=4))

--- a/semantic_release/version/algorithm.py
+++ b/semantic_release/version/algorithm.py
@@ -160,6 +160,7 @@ def _increment_version(
             level_bump,
             latest_full_version_in_history,
         )
+        log.debug("this release will increment the prerelease revision")
         return latest_version.to_prerelease(
             token=prerelease_token,
             revision=(

--- a/semantic_release/version/translator.py
+++ b/semantic_release/version/translator.py
@@ -20,7 +20,7 @@ class VersionTranslator:
 
     @classmethod
     def _invert_tag_format_to_re(cls, tag_format: str) -> re.Pattern[str]:
-        """
+        r"""
         Unpick the "tag_format" format string and create a regex which can be used to
         convert a tag to a version string.
 

--- a/tests/unit/semantic_release/cli/test_version.py
+++ b/tests/unit/semantic_release/cli/test_version.py
@@ -1,0 +1,23 @@
+import pytest
+
+from semantic_release.cli.commands.version import is_forced_prerelease
+
+
+@pytest.mark.parametrize(
+    "force_prerelease, force_level, prerelease, expected",
+    [
+        *[
+            (True, force_level, prerelease, True)
+            for force_level in (None, "major", "minor", "patch")
+            for prerelease in (True, False)
+        ],
+        *[
+            (False, force_level, prerelease, False)
+            for force_level in ("major", "minor", "patch")
+            for prerelease in (True, False)
+        ],
+        *[(False, None, prerelease, prerelease) for prerelease in (True, False)],
+    ],
+)
+def test_is_forced_prerelease(force_prerelease, force_level, prerelease, expected):
+    assert is_forced_prerelease(force_prerelease, force_level, prerelease) == expected


### PR DESCRIPTION
fixed a project url in metadata
added some logging
added a new option to generate-config which allows choice of tool.semantic_release or semantic_release in toml config fixed a logic flaw around prerelease handling from an already-configured prerelease branch fixed a syntax warning in VersionTranslator docstring updated docs with mention of logic flow and new option for generate-config command added some quick tests for logic for forcing prerelease